### PR TITLE
Update README with INSTALL_VERSION usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,26 @@ HYPE is a Bash-based CLI tool that simplifies the deployment and management of K
 ### Quick Install
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/your-repo/hype/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | bash
+```
+
+### Install Specific Version
+
+You can install a specific version using the `INSTALL_VERSION` environment variable:
+
+```bash
+# Install specific version
+INSTALL_VERSION=v0.2.1 curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | bash
+
+# Or download and run locally
+curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh -o install.sh
+INSTALL_VERSION=v0.2.1 ./install.sh
 ```
 
 ### Manual Install
 
 ```bash
-git clone https://github.com/your-repo/hype.git
+git clone https://github.com/foontype/hype.git
 cd hype
 ./install.sh
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can install a specific version using the `INSTALL_VERSION` environment varia
 
 ```bash
 # Install specific version
-INSTALL_VERSION=v0.2.1 curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | INSTALL_VERSION=v0.2.1 bash
 
 # Or download and run locally
 curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh -o install.sh


### PR DESCRIPTION
## Summary
- Add documentation for INSTALL_VERSION environment variable in README
- Update repository URLs from placeholder to actual foontype/hype
- Provide clear installation examples for specific versions

## Changes
- Added "Install Specific Version" section with usage examples
- Fixed repository URLs in installation commands
- Improved installation documentation with proper syntax examples

## Usage Examples Added
```bash
# Install specific version
curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | INSTALL_VERSION=v0.2.1 bash

# Or download and run locally
curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh -o install.sh
INSTALL_VERSION=v0.2.1 ./install.sh
```

## Fixes
- Repository URLs updated from `your-repo/hype` to `foontype/hype`
- Correct environment variable syntax for piped installation

🤖 Generated with [Claude Code](https://claude.ai/code)