### PR TITLE
Add debug logging for temporary file contents

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,24 @@
+"v0.2.2": |
+  ## What's New in HYPE CLI v0.2.2
+
+  ### New Features
+  - **Enhanced Debug Logging**: Added detailed debug output for temporary files when DEBUG=true
+    - Show hype section content during parsing
+    - Show helmfile section content during parsing
+    - Show state values file content during helmfile operations
+  
+  ### Improvements
+  - Better debugging experience for troubleshooting hypefile processing
+  - More visibility into internal file processing workflows
+  - Improved development and testing capabilities
+
+  ### Technical Changes
+  - Added debug content display in parse_hypefile() function
+  - Added debug content display in cmd_helmfile() for state values files
+  - Enhanced temporary file content visibility for debugging
+
+  This release improves the debugging experience by providing detailed visibility into temporary file contents when running in debug mode.
+
 "v0.0.1": |
   Initial release of HYPE CLI
 

--- a/src/hype
+++ b/src/hype
@@ -131,6 +131,17 @@ parse_hypefile() {
     sed -i "s/{{ \.Hype\.Name }}/$hype_name/g" "$HELMFILE_SECTION_FILE"
     
     debug "Created temporary files: $HYPE_SECTION_FILE, $HELMFILE_SECTION_FILE"
+    
+    # Debug: Show contents of temporary files
+    if [[ "$DEBUG" == "true" ]]; then
+        debug "=== HYPE SECTION CONTENT ==="
+        cat "$HYPE_SECTION_FILE" >&2
+        debug "=== END HYPE SECTION ==="
+        
+        debug "=== HELMFILE SECTION CONTENT ==="
+        cat "$HELMFILE_SECTION_FILE" >&2
+        debug "=== END HELMFILE SECTION ==="
+    fi
 }
 
 # Cleanup temporary files
@@ -461,6 +472,13 @@ cmd_helmfile() {
                 cmd+=("--state-values-file" "$state_file")
                 
                 debug "Added state-values-file: $state_file for ConfigMap: $name"
+                
+                # Debug: Show contents of state values file
+                if [[ "$DEBUG" == "true" ]]; then
+                    debug "=== STATE VALUES FILE CONTENT ($name) ==="
+                    cat "$state_file" >&2
+                    debug "=== END STATE VALUES FILE ==="
+                fi
                 
                 # Clean up state file when done
                 # shellcheck disable=SC2064

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.2.1"
+HYPE_VERSION="0.2.2"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 
 # Colors for output


### PR DESCRIPTION
## Summary
- Enhanced debug functionality to show temporary file contents when DEBUG=true
- Displays hype section content during parsing
- Displays helmfile section content during parsing
- Displays state values file content during helmfile operations

## Test plan
- [ ] Test with DEBUG=true environment variable
- [ ] Verify debug output shows temporary file contents
- [ ] Ensure normal operation without DEBUG flag remains unchanged
- [ ] Test with various hypefile configurations

🤖 Generated with [Claude Code](https://claude.ai/code)