### PR TITLE
Fix ConfigMap data extraction and bump version to 0.3.1

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,16 @@
+"v0.3.1": |
+  ## What's New in HYPE CLI v0.3.1
+
+  ### Bug Fixes
+  - **ConfigMap Data Extraction**: Fixed StateValueConfigmap processing to extract all data from ConfigMaps instead of only `.data.nginx` field
+  - Improved ConfigMap integration for helmfile state values
+
+  ### Technical Changes
+  - Updated kubectl jsonpath query from `{.data.nginx}` to `{.data}` for complete ConfigMap data extraction
+  - Enhanced ConfigMap to YAML conversion workflow
+
+  This is a patch release that fixes ConfigMap data extraction for more flexible state value management.
+
 "v0.3.0": |
   ## What's New in HYPE CLI v0.3.0
 

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.3.0"
+HYPE_VERSION="0.3.1"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 
 # Colors for output
@@ -483,7 +483,7 @@ EOF
                 local state_file
                 state_file=$(mktemp)
                 # Extract and parse the JSON data from ConfigMap, convert to YAML
-                kubectl get configmap "$name" -o jsonpath='{.data.nginx}' | jq '.' | yq eval -P - > "$state_file"
+                kubectl get configmap "$name" -o jsonpath='{.data}' | jq '.' | yq eval -P - > "$state_file"
                 cmd+=("--state-values-file" "$state_file")
                 
                 debug "Added state-values-file: $state_file for ConfigMap: $name"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fix StateValueConfigmap processing to extract all data from ConfigMaps instead of only `.data.nginx` field
- Update version from 0.3.0 to 0.3.1
- Add v0.3.1 release notes

## Changes
- **ConfigMap Data Fix**: Changed kubectl jsonpath query from `{.data.nginx}` to `{.data}` for complete ConfigMap data extraction in `src/hype:486`
- **Version Bump**: Updated `HYPE_VERSION` from "0.3.0" to "0.3.1" in `src/hype:5`
- **Release Notes**: Added comprehensive v0.3.1 release notes to `release-notes.yaml`

## Test plan
- [x] Verify version update in script
- [x] Confirm ConfigMap data extraction fix
- [x] Validate release notes format consistency

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)