### PR TITLE
Add comprehensive debug logging to resource values processing

### DIFF
--- a/.claude/test.md
+++ b/.claude/test.md
@@ -7,14 +7,16 @@ cd examples/nginx
 
 ../../src/hype test check
   * kubectl を使って、test-nginx-configmap, test-nginx-state-value, test-nginx-secrets があることを確認
+  * configmap, secrets の内容が、YAML 形式であること
+  * configmap, secrets の key に対する value の値が JSON 形式で展開されていないこと
 
 ../../src/hype test helmfile template
-  * デバッグログで helmfile template 実行時の引数に、--state-value-file オプションで state value configmap の一時ファイルが指定されていること
-  * デバッグログで helmfile template 実行時の引数に、--state-value-file オプションで hype.currentDirectory を含む一時ファイルが指定されていること
-  * デバッグログで state value configmap の一時ファイルに、state value file の元になったconfigmap と同等の構造が出力されていること
-  * デバッグログで helmfile section の一時ファイルに、hypefile.yaml の helmfile section の内容が出力されていること
-  * デバッグログで helmfile section の一時ファイルの拡張子が .yaml.gotmpl であること
-  * デバッグログで hype section の一時ファイルに、hypefile.yaml の hype section の内容が出力されていること
+  * デバッグログで、helmfile template 実行時の引数に、--state-value-file オプションで state value configmap の一時ファイルが指定されていること
+  * デバッグログで、helmfile template 実行時の引数に、--state-value-file オプションで hype.currentDirectory を含む一時ファイルが指定されていること
+  * デバッグログで、state value configmap の一時ファイルについて、一時ファイルに configmap と同等の構造が出力されていること
+  * デバッグログで、hype section の一時ファイルに、hypefile.yaml の hype section の内容が出力されていること
+  * デバッグログで、helmfile section の一時ファイルに、hypefile.yaml の helmfile section の内容が出力されていること
+  * デバッグログで、helmfile section の一時ファイルの拡張子が .yaml.gotmpl であること
 
 ../../src/hype test helmfile apply
   * kubectl を使って nginx がアップしていること

--- a/src/hype
+++ b/src/hype
@@ -192,6 +192,7 @@ create_resource() {
                 [[ -n "$arg" ]] && kubectl_args+=("$arg")
             done < <(get_resource_values "$values_yaml" "$tmpdir")
             
+            debug "Executing kubectl command: ${kubectl_args[*]}"
             kubectl "${kubectl_args[@]}"
             info "Created ConfigMap: $name"
             ;;
@@ -207,6 +208,7 @@ create_resource() {
                 [[ -n "$arg" ]] && kubectl_args+=("$arg")
             done < <(get_resource_values "$values_yaml" "$tmpdir")
             
+            debug "Executing kubectl command: ${kubectl_args[*]}"
             kubectl "${kubectl_args[@]}"
             info "Created Secret: $name"
             ;;
@@ -279,6 +281,13 @@ get_resource_values() {
     
     debug "Processing values_yaml with tmpdir: $tmpdir"
     
+    # Debug: Show input YAML structure
+    if [[ "$DEBUG" == "true" ]]; then
+        debug "=== INPUT YAML ==="
+        echo "$values_yaml" | yq eval -P - >&2
+        debug "=== END INPUT YAML ==="
+    fi
+    
     # ① Create YAML files for complex structures (arrays/objects/multiline)
     echo "$values_yaml" \
       | yq eval -o=json - \
@@ -289,8 +298,15 @@ get_resource_values() {
         ' \
       | bash
     
+    # Debug: List created files
+    if [[ "$DEBUG" == "true" ]] && [[ -d "$tmpdir" ]]; then
+        debug "Created temporary files in $tmpdir:"
+        ls -la "$tmpdir" >&2 || true
+    fi
+    
     # ② Generate kubectl arguments for all keys
-    echo "$values_yaml" \
+    local kubectl_args
+    kubectl_args=$(echo "$values_yaml" \
       | yq eval -o=json - \
       | jq -r '
           to_entries[]
@@ -299,7 +315,16 @@ get_resource_values() {
             else
               "--from-file=\(.key)='"$tmpdir"'/\(.key).yaml"
             end
-        '
+        ')
+    
+    # Debug: Show generated kubectl arguments
+    if [[ "$DEBUG" == "true" ]]; then
+        debug "=== GENERATED KUBECTL ARGUMENTS ==="
+        echo "$kubectl_args" >&2
+        debug "=== END KUBECTL ARGUMENTS ==="
+    fi
+    
+    echo "$kubectl_args"
 }
 
 # Initialize default resources


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
Adds comprehensive debug logging to the resource values processing system introduced in #54. This enhancement improves debugging experience when `DEBUG=true` is set.

## Changes Made
- **Input YAML logging**: Show the structure of input YAML values before processing
- **Temporary file tracking**: List all temporary files created for complex values
- **kubectl arguments visibility**: Display generated kubectl arguments for transparency
- **Command execution logging**: Show the actual kubectl commands being executed
- **Conditional debug output**: All debug output is properly gated behind `DEBUG=true`

## Debug Output Examples
When `DEBUG=true`:
```
[DEBUG] Processing values_yaml with tmpdir: /tmp/tmp.xyz123
[DEBUG] === INPUT YAML ===
config:
  servers:
    - host: server1
      port: 8080
[DEBUG] === END INPUT YAML ===
[DEBUG] Created temporary files in /tmp/tmp.xyz123:
-rw-r--r-- 1 user user 45 Aug 25 19:30 config.yaml
[DEBUG] === GENERATED KUBECTL ARGUMENTS ===
--from-file=config=/tmp/tmp.xyz123/config.yaml
[DEBUG] === END KUBECTL ARGUMENTS ===
[DEBUG] Executing kubectl command: create configmap my-config --from-file=config=/tmp/tmp.xyz123/config.yaml
```

## Test Plan
- [x] Code passes shellcheck linting
- [x] Debug output is properly gated behind DEBUG flag
- [ ] Test debug output with simple values
- [ ] Test debug output with complex YAML structures
- [ ] Verify no performance impact when DEBUG=false

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)