### PR TITLE
Bump version to 0.3.5 and add release notes

### DIFF
--- a/RELEASE_NOTES_v0.3.5.md
+++ b/RELEASE_NOTES_v0.3.5.md
@@ -1,0 +1,49 @@
+# HYPE v0.3.5 Release Notes
+
+## 🚀 New Features
+
+### Template State-Value Subcommand
+- **New subcommand**: `hype <name> template state-value <configmap-name>`
+- Allows users to inspect the actual YAML content that would be passed to helmfile as state-value-file from a StateValueConfigmap
+- Validates that the specified ConfigMap exists and is of StateValueConfigmap type
+- Extracts and displays YAML content from the `data.values` key
+- Provides helpful error messages for debugging state-value configurations
+
+## 🔧 Improvements
+
+### Enhanced Debugging Capabilities
+- Users can now view and verify state-value content before helmfile execution
+- Better visibility into the YAML structure being passed to helmfile
+- Improved troubleshooting for state-value related issues
+
+### Backward Compatibility
+- The original `template` command remains unchanged
+- All existing functionality is preserved
+
+## 📝 Usage Examples
+
+```bash
+# View state-value content from a ConfigMap
+hype myapp template state-value my-state-configmap
+
+# The original template command still works as before
+hype myapp helmfile template
+```
+
+## 🐛 Bug Fixes
+
+- Improved error handling for missing or invalid ConfigMaps
+- Enhanced validation for StateValueConfigmap type checking
+
+## 📊 Changes Summary
+
+- **Files changed**: 1
+- **Lines added**: +140
+- **Lines removed**: -19
+- **Net change**: +121 lines
+
+---
+
+**Full Changelog**: [v0.3.4...v0.3.5](https://github.com/foontype/hype/compare/v0.3.4...v0.3.5)
+
+This release focuses on improving the debugging experience for users working with state-value configurations, making it easier to troubleshoot and verify ConfigMap content before deployment.

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.3.4"
+HYPE_VERSION="0.3.5"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 
 # Colors for output


### PR DESCRIPTION
## Summary

This PR bumps the version to 0.3.5 and includes comprehensive release notes for the new template state-value subcommand feature.

## Changes

- 🔄 **Version Update**: Bumped `HYPE_VERSION` from `0.3.4` to `0.3.5` in `src/hype`
- 📝 **Release Notes**: Added detailed `RELEASE_NOTES_v0.3.5.md` documenting all new features and improvements

## What's New in v0.3.5

### 🚀 New Features
- **Template State-Value Subcommand**: New `hype <name> template state-value <configmap-name>` command for inspecting StateValueConfigmap content
- Enhanced debugging capabilities for state-value configurations
- Better visibility into YAML structure being passed to helmfile

### 🔧 Improvements  
- Improved error handling and validation
- Backward compatibility maintained
- Enhanced troubleshooting capabilities

## Test Plan

- [x] Version number correctly updated in source code
- [x] Release notes accurately reflect recent changes since v0.3.4
- [x] All existing functionality preserved
- [x] New template state-value subcommand verified working

## Release Process

Once merged, this will enable:
1. Creating the v0.3.5 git tag  
2. Automated GitHub release via GitHub Actions
3. Updated installation script availability

🤖 Generated with [Claude Code](https://claude.ai/code)