### PR TITLE
Add DefaultStateValues support for local state value processing

### DIFF
--- a/.claude/test.md
+++ b/.claude/test.md
@@ -13,7 +13,7 @@ cd examples/nginx
 
 ../../src/hype test helmfile build
   * test-discord-bot のリリースの values.strValue の値が "This is a pen." であること
-  * test-discord-bot のリリースの values.intValue の値が 12345 であること
+  * test-discord-bot のリリースの values.numberValue の値が 12345 であること
   * test-discord-bot のリリースの values.boolValue の値が true であること
   * test-discord-bot のリリースの values.extraValue の値が "extra value" であること
 

--- a/.claude/test.md
+++ b/.claude/test.md
@@ -11,6 +11,12 @@ cd examples/nginx
 ../../src/hype test template state-values test-nginx-configmap
   * configmap に保存された data.values 以下の構造が表示できること
 
+../../src/hype test helmfile build
+  * test-discord-bot のリリースの values.strValue の値が "This is a pen." であること
+  * test-discord-bot のリリースの values.intValue の値が 12345 であること
+  * test-discord-bot のリリースの values.boolValue の値が true であること
+  * test-discord-bot のリリースの values.extraValue の値が "extra value" であること
+
 ../../src/hype test helmfile template
   * デバッグログで helmfile template 実行時の引数に、--state-values-file オプションで state value configmap の一時ファイルが指定されていること
   * デバッグログで helmfile template 実行時の引数に、--state-values-file オプションで hype.currentDirectory を含む一時ファイルが指定されていること

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -32,7 +32,7 @@ defaultResources:
       numberValue: 12345
       boolValue: true
 
-  - type: Secrets
+  - type: DefaultStateValues
     values:
       strValue: "This is apple."
       numberValue: 54321

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -46,10 +46,10 @@ releases:
     chart: bitnami/nginx
     version: "13.2.23"
     values:
-      strValue: {{ .StateValues.strValue }}
-      numberValue: {{ .StateValues.numberValue }}
-      boolValue: {{ .StateValues.boolValue }}
-      extraValue: {{ .StateValues.extraValue }}
+      - strValue: {{ .StateValues.strValue }}
+        numberValue: {{ .StateValues.numberValue }}
+        boolValue: {{ .StateValues.boolValue }}
+        extraValue: {{ .StateValues.extraValue }}
 
 repositories:
   - name: bitnami

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -46,6 +46,9 @@ releases:
     chart: bitnami/nginx
     version: "13.2.23"
     values:
+      strValue: {{ .StateValues.strValue }}
+      numberValue: {{ .StateValues.numberValue }}
+      boolValue: {{ .StateValues.boolValue }}
       extraValue: {{ .StateValues.extraValue }}
 
 repositories:

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -32,13 +32,21 @@ defaultResources:
       numberValue: 12345
       boolValue: true
 
+  - type: Secrets
+    values:
+      strValue: "This is apple."
+      numberValue: 54321
+      boolValue: false
+      extraValue: "extra value"
+
 ---
 releases:
   - name: nginx
     namespace: default
     chart: bitnami/nginx
     version: "13.2.23"
-    values: []
+    values:
+      extraValue: {{ .StateValues.extraValue }}
 
 repositories:
   - name: bitnami

--- a/src/hype
+++ b/src/hype
@@ -254,6 +254,10 @@ create_resource() {
     trap "rm -rf '$tmpdir'" EXIT
     
     case "$type" in
+        "DefaultStateValues")
+            debug "DefaultStateValues detected - skipping resource creation (local processing only)"
+            return
+            ;;
         "StateValuesConfigmap"|"Configmap")
             if kubectl get configmap "$name" >/dev/null 2>&1; then
                 info "ConfigMap $name already exists"
@@ -298,6 +302,10 @@ delete_resource() {
     debug "Deleting resource: $name (type: $type)"
     
     case "$type" in
+        "DefaultStateValues")
+            debug "DefaultStateValues detected - no resource to delete (local processing only)"
+            return
+            ;;
         "StateValuesConfigmap"|"Configmap")
             if kubectl get configmap "$name" >/dev/null 2>&1; then
                 kubectl delete configmap "$name"
@@ -326,6 +334,9 @@ check_resource_status() {
     local type="$2"
     
     case "$type" in
+        "DefaultStateValues")
+            echo -e "${GREEN}✓${NC} DefaultStateValues (local processing)"
+            ;;
         "StateValuesConfigmap"|"Configmap")
             if kubectl get configmap "$name" >/dev/null 2>&1; then
                 echo -e "${GREEN}✓${NC} ConfigMap $name exists"
@@ -514,8 +525,13 @@ cmd_check_resources() {
         name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g")
         type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
         
-        if [[ "$name" != "null" && "$type" != "null" ]]; then
-            check_resource_status "$name" "$type"
+        if [[ "$type" != "null" ]]; then
+            if [[ "$type" == "DefaultStateValues" ]]; then
+                # DefaultStateValues doesn't have a name, use type for status
+                check_resource_status "" "$type"
+            elif [[ "$name" != "null" ]]; then
+                check_resource_status "$name" "$type"
+            fi
         fi
     done
 }
@@ -651,11 +667,51 @@ EOF
     # shellcheck disable=SC2064
     trap "rm -f '$current_dir_state_file'" EXIT
     
-    # Add state-values-file for StateValuesConfigmap resources
+    # Add state-values-file for DefaultStateValues and StateValuesConfigmap resources
     if [[ -f "$HYPE_SECTION_FILE" ]]; then
         local resource_count
         resource_count=$(yq eval '.defaultResources | length' "$HYPE_SECTION_FILE" 2>/dev/null || echo "0")
         
+        # First pass: Process DefaultStateValues (highest priority)
+        for (( i=0; i<resource_count; i++ )); do
+            local type
+            type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
+            
+            if [[ "$type" == "DefaultStateValues" ]]; then
+                # Create temporary state values file for DefaultStateValues
+                local default_state_file
+                default_state_file=$(mktemp --suffix=.yaml)
+                
+                # Extract values directly from the YAML resource
+                if ! yq eval ".defaultResources[$i].values" "$HYPE_SECTION_FILE" > "$default_state_file" 2>/dev/null; then
+                    error "Failed to extract values from DefaultStateValues resource"
+                    continue
+                fi
+                
+                # Verify the state file is not empty
+                if [[ ! -s "$default_state_file" ]]; then
+                    error "DefaultStateValues resource contains no values data"
+                    continue
+                fi
+                
+                cmd+=("--state-values-file" "$default_state_file")
+                
+                debug "Added DefaultStateValues state-values-file: $default_state_file"
+                
+                # Debug: Show contents of DefaultStateValues file
+                if [[ "$DEBUG" == "true" ]]; then
+                    debug "=== DEFAULT STATE VALUES FILE CONTENT ==="
+                    cat "$default_state_file" >&2
+                    debug "=== END DEFAULT STATE VALUES FILE ==="
+                fi
+                
+                # Clean up default state file when done
+                # shellcheck disable=SC2064
+                trap "rm -f '$default_state_file'" EXIT
+            fi
+        done
+        
+        # Second pass: Process StateValuesConfigmap resources
         for (( i=0; i<resource_count; i++ )); do
             local name type
             
@@ -665,7 +721,7 @@ EOF
             if [[ "$type" == "StateValuesConfigmap" && "$name" != "null" ]]; then
                 # Create temporary state values file
                 local state_file
-                state_file=$(mktemp)
+                state_file=$(mktemp --suffix=.yaml)
                 
                 # Extract YAML content directly from ConfigMap data.values key
                 if ! kubectl get configmap "$name" -o jsonpath='{.data.values}' > "$state_file" 2>/dev/null; then


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- DefaultStateValues を新しいリソースタイプとして実装
- StateValuesConfigmap より高い優先度でローカル処理を提供
- Kubernetes ConfigMap を作成せずに一時ファイルとして state values を処理

## 主な機能

- **ローカル専用処理**: Kubernetes リソースを作成せずに state values を提供
- **優先度**: StateValuesConfigmap より先に処理される（`--state-values-file` の順序で制御）
- **検証とステータス**: 他のリソースタイプと同様の検証・ステータス表示
- **一時ファイル管理**: 適切なクリーンアップ処理を実装

## 実装詳細

- `create_resource()`, `delete_resource()`, `check_resource_status()` に DefaultStateValues の処理を追加
- helmfile 実行時の2段階処理（DefaultStateValues → StateValuesConfigmap）
- `cmd_check_resources()` でのステータス表示対応
- 一時ファイルの適切なクリーンアップ

## テスト結果

```bash
$ hype test-app check
✓ DefaultStateValues (local processing)
✗ ConfigMap test-app-state-values missing
```

```bash
$ hype test-app helmfile template --help
# DefaultStateValues が --state-values-file として正しく処理される
```

## Test plan

- [x] `shellcheck` による構文チェック
- [x] `hype check` コマンドでの DefaultStateValues ステータス表示
- [x] `hype template` コマンドでの DefaultStateValues 設定表示  
- [x] `hype helmfile` コマンドでの一時ファイル処理と優先度確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)