### PR TITLE
Update StateValues structure for better naming consistency

### DIFF
--- a/.claude/test.md
+++ b/.claude/test.md
@@ -12,6 +12,8 @@ cd examples/nginx
   * configmap に保存された data.values 以下の構造が表示できること
 
 ../../src/hype test helmfile build
+  * test-discord-bot のリリースの values.autoHypeCurrentDirectory の値がカレントディレクトリであること
+  * test-discord-bot のリリースの values.autoHypeName の値が test であること
   * test-discord-bot のリリースの values.strValue の値が "This is a pen." であること
   * test-discord-bot のリリースの values.numberValue の値が 12345 であること
   * test-discord-bot のリリースの values.boolValue の値が true であること

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -46,7 +46,9 @@ releases:
     chart: bitnami/nginx
     version: "13.2.23"
     values:
-      - strValue: {{ .StateValues.strValue }}
+      - hypeCurrentDirectory: {{ .StateValues.Hype.CurrentDirectory }}
+        hypeName: {{ .StateValues.Hype.Name }}
+        strValue: {{ .StateValues.strValue }}
         numberValue: {{ .StateValues.numberValue }}
         boolValue: {{ .StateValues.boolValue }}
         extraValue: {{ .StateValues.extraValue }}

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -46,8 +46,8 @@ releases:
     chart: bitnami/nginx
     version: "13.2.23"
     values:
-      - hypeCurrentDirectory: {{ .StateValues.Hype.CurrentDirectory }}
-        hypeName: {{ .StateValues.Hype.Name }}
+      - autoHypeCurrentDirectory: {{ .StateValues.Hype.CurrentDirectory }}
+        autoHypeName: {{ .StateValues.Hype.Name }}
         strValue: {{ .StateValues.strValue }}
         numberValue: {{ .StateValues.numberValue }}
         boolValue: {{ .StateValues.boolValue }}

--- a/src/hype
+++ b/src/hype
@@ -656,12 +656,13 @@ cmd_helmfile() {
     local current_dir_state_file
     current_dir_state_file=$(mktemp --suffix=.yaml)
     cat > "$current_dir_state_file" << EOF
-hype:
-  currentDirectory: "$(pwd)"
+Hype:
+  CurrentDirectory: "$(pwd)"
+  Name: "$hype_name"
 EOF
     cmd+=("--state-values-file" "$current_dir_state_file")
     
-    debug "Added current directory state values: $(pwd)"
+    debug "Added Hype state values - CurrentDirectory: $(pwd), Name: $hype_name"
     
     # Clean up current directory state file when done
     # shellcheck disable=SC2064


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Change `.StateValues.hype.currentDirectory` to `.StateValues.Hype.CurrentDirectory` for Pascal case consistency
- Add `.StateValues.Hype.Name` to provide access to the hype name in templates
- Update debug logging to reflect new state values structure

## Changes Made
- **Breaking Change**: State value path changed from `hype.currentDirectory` to `Hype.CurrentDirectory`
- **New Feature**: Added `Hype.Name` containing the hype name specified in the command
- Updated debug output to show both values for better troubleshooting

## Test Plan
- [x] Shellcheck passes without errors
- [x] Basic CLI functionality works (`hype --help`, `hype --version`)
- [x] Debug output shows correct state values generation
- [x] Template rendering works with new state value structure

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)