### PR TITLE
Add support for {{ .Hype.CurrentDirectory }} template variable

### DIFF
--- a/.claude/test.md
+++ b/.claude/test.md
@@ -14,6 +14,9 @@ cd examples/nginx
 ../../src/hype test helmfile build
   * test-discord-bot のリリースの values.autoHypeCurrentDirectory の値がカレントディレクトリであること
   * test-discord-bot のリリースの values.autoHypeName の値が test であること
+../../src/hype test helmfile build
+  * test-discord-bot のリリースの values.hypeCurrentDirectoryValue の値がカレントディレクトリであること
+  * test-discord-bot のリリースの values.hypeNameValue の値が test であること
   * test-discord-bot のリリースの values.strValue の値が "This is a pen." であること
   * test-discord-bot のリリースの values.numberValue の値が 12345 であること
   * test-discord-bot のリリースの values.boolValue の値が true であること

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -17,6 +17,8 @@ defaultResources:
               paths:
                 - path: /
                   pathType: Prefix
+      hypeCurrentDirectoryValue: {{ .Hype.CurrentDirectory }}
+      hypeNameValue: {{ .Hype.Name }}
       strValue: "This is a pen."
       numberValue: 12345
       boolValue: true
@@ -34,6 +36,7 @@ defaultResources:
 
   - type: DefaultStateValues
     values:
+      
       strValue: "This is apple."
       numberValue: 54321
       boolValue: false
@@ -48,6 +51,8 @@ releases:
     values:
       - autoHypeCurrentDirectory: {{ .StateValues.Hype.CurrentDirectory }}
         autoHypeName: {{ .StateValues.Hype.Name }}
+        hypeCurrentDirectoryValue: {{ .StateValues.hypeCurrentDirectoryValue }}
+        hypeNameValue: {{ .StateValues.hypeNameValue }}
         strValue: {{ .StateValues.strValue }}
         numberValue: {{ .StateValues.numberValue }}
         boolValue: {{ .StateValues.boolValue }}

--- a/examples/nginx/hypefile.yaml
+++ b/examples/nginx/hypefile.yaml
@@ -1,4 +1,3 @@
-
 defaultResources:
   - name: "{{ .Hype.Name }}-nginx-state-values"
     type: StateValuesConfigmap

--- a/src/hype
+++ b/src/hype
@@ -140,9 +140,11 @@ parse_hypefile() {
     section == "helmfile" { print > helmfile_file }
     ' "$HYPEFILE"
     
-    # Replace {{ .Hype.Name }} with actual hype name
+    # Replace {{ .Hype.Name }} with actual hype name and {{ .Hype.CurrentDirectory }} with current directory
     sed -i "s/{{ \.Hype\.Name }}/$hype_name/g" "$HYPE_SECTION_FILE"
     sed -i "s/{{ \.Hype\.Name }}/$hype_name/g" "$HELMFILE_SECTION_FILE"
+    sed -i "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g" "$HYPE_SECTION_FILE"
+    sed -i "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g" "$HELMFILE_SECTION_FILE"
     
     debug "Created temporary files: $HYPE_SECTION_FILE, $HELMFILE_SECTION_FILE"
     
@@ -208,7 +210,7 @@ validate_state_values_configmap() {
     for (( i=0; i<resource_count; i++ )); do
         local name type
         
-        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g")
+        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g" | sed "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g")
         type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
         
         debug "Checking resource $i: name=$name, type=$type"
@@ -442,7 +444,7 @@ cmd_init() {
     for (( i=0; i<resource_count; i++ )); do
         local name type values_yaml
         
-        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g")
+        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g" | sed "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g")
         type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
         values_yaml=$(yq eval ".defaultResources[$i].values" "$HYPE_SECTION_FILE")
         
@@ -482,7 +484,7 @@ cmd_deinit() {
     for (( i=0; i<resource_count; i++ )); do
         local name type
         
-        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g")
+        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g" | sed "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g")
         type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
         
         debug "Processing resource $i for deletion: name=$name, type=$type"
@@ -522,7 +524,7 @@ cmd_check_resources() {
     for (( i=0; i<resource_count; i++ )); do
         local name type
         
-        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g")
+        name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g" | sed "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g")
         type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
         
         if [[ "$type" != "null" ]]; then
@@ -716,7 +718,7 @@ EOF
         for (( i=0; i<resource_count; i++ )); do
             local name type
             
-            name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g")
+            name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g" | sed "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g")
             type=$(yq eval ".defaultResources[$i].type" "$HYPE_SECTION_FILE")
             
             if [[ "$type" == "StateValuesConfigmap" && "$name" != "null" ]]; then


### PR DESCRIPTION
## Summary

- Added support for `{{ .Hype.CurrentDirectory }}` template variable replacement
- Extended existing template replacement functionality to handle current working directory
- Applied to both hype and helmfile sections consistently

## Changes

- **parse_hypefile()**: Added CurrentDirectory template replacement alongside existing Name replacement
- **Resource processing**: Extended all name resolution locations to handle CurrentDirectory templates
- **Compatibility**: Maintains full backward compatibility with existing `{{ .Hype.Name }}` functionality

## Test plan

- [x] Verified syntax with shellcheck
- [x] Tested template replacement with test hypefile
- [x] Confirmed both hype and helmfile sections process templates correctly
- [x] Validated CurrentDirectory resolves to actual working directory path

## Examples

```yaml
# Before - only Name supported
name: "{{ .Hype.Name }}-configmap"

# After - both Name and CurrentDirectory supported  
name: "{{ .Hype.Name }}-configmap"
values:
  workingDir: "{{ .Hype.CurrentDirectory }}"
  appName: "{{ .Hype.Name }}"
```

🤖 Generated with [Claude Code](https://claude.ai/code)