### PR TITLE
Refactor section subcommand to parse section structure

### DIFF
--- a/.claude/test.md
+++ b/.claude/test.md
@@ -3,6 +3,12 @@ cd examples/nginx
 ../../src/hype test check
   * kubectl を使って、test-nginx-configmap, test-nginx-state-values, test-nginx-secrets がないことを確認
 
+../../src/hype test parse section hype
+  * hypefile.yaml の hype セクションが表示されること
+
+../../src/hype test parse section helmfile
+  * hypefile.yaml の helmfile セクションが表示されること
+
 ../../src/hype test init
 
 ../../src/hype test check

--- a/src/hype
+++ b/src/hype
@@ -85,7 +85,7 @@ Usage:
   hype <hype-name> check                                         List default resources status
   hype <hype-name> template                                      Show rendered hype section YAML
   hype <hype-name> template state-values <configmap-name>        Show state-values file content
-  hype <hype-name> section [hype|helmfile]                      Show raw section without headers
+  hype <hype-name> parse section <hype|helmfile>                Show raw section without headers
   hype <hype-name> helmfile <helmfile-options>                  Run helmfile command
   hype --version                                                 Show version
   hype --help                                                    Show this help
@@ -103,9 +103,8 @@ Examples:
   hype my-nginx init                                             Create resources for my-nginx
   hype my-nginx template                                         Show rendered YAML for my-nginx
   hype my-nginx template state-values my-nginx-state-values      Show state-values content
-  hype my-nginx section hype                                     Show raw hype section
-  hype my-nginx section helmfile                                Show raw helmfile section
-  hype my-nginx section                                          Show raw hype section (default)
+  hype my-nginx parse section hype                              Show raw hype section
+  hype my-nginx parse section helmfile                          Show raw helmfile section
   hype my-nginx helmfile apply                                   Apply helmfile for my-nginx
   hype my-nginx check                                            Check resource status
   hype my-nginx deinit                                           Remove all resources
@@ -614,10 +613,39 @@ cmd_template_state_value() {
     echo "$state_values"
 }
 
-# Show raw sections without rendering info headers
-cmd_section() {
+# Parse command router
+cmd_parse() {
     local hype_name="$1"
-    local section_type="${2:-hype}"
+    local subcommand="${2:-}"
+    
+    case "$subcommand" in
+        "section")
+            local section_type="${3:-}"
+            cmd_parse_section "$hype_name" "$section_type"
+            ;;
+        "")
+            error "Missing parse subcommand"
+            error "Usage: hype <hype-name> parse section [hype|helmfile]"
+            exit 1
+            ;;
+        *)
+            error "Unknown parse subcommand: $subcommand"
+            error "Valid options: section"
+            exit 1
+            ;;
+    esac
+}
+
+# Show raw sections without rendering info headers
+cmd_parse_section() {
+    local hype_name="$1"
+    local section_type="$2"
+    
+    if [[ -z "$section_type" ]]; then
+        error "Section type is required"
+        error "Usage: hype <hype-name> parse section [hype|helmfile]"
+        exit 1
+    fi
     
     parse_hypefile "$hype_name"
     
@@ -807,8 +835,8 @@ main() {
                 "template")
                     cmd_template "$hype_name" "$@"
                     ;;
-                "section")
-                    cmd_section "$hype_name" "$@"
+                "parse")
+                    cmd_parse "$hype_name" "$@"
                     ;;
                 "helmfile")
                     cmd_helmfile "$hype_name" "$@"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Change `hype <name> section [hype|helmfile]` to `hype <name> parse section <hype|helmfile>`
- Make hype|helmfile parameter mandatory (no default value)
- Add comprehensive error handling for missing required parameters

## Changes Made
- Added new `cmd_parse()` router function for parse subcommands
- Replaced `cmd_section()` with `cmd_parse_section()` with required parameter validation  
- Updated help text and examples to reflect new command structure
- Updated main function routing from "section" to "parse"

## Test Plan
- [x] Help text displays correct new syntax
- [x] Error handling works for missing parse subcommand
- [x] Error handling works for missing section type parameter
- [x] shellcheck validation passes
- [x] Command structure requires mandatory hype|helmfile parameter

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)