### PR TITLE
Add self-upgrade functionality to HYPE CLI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # Configuration
 INSTALL_DIR="/usr/local/bin"
 SCRIPT_NAME="hype"
-REPO_URL="https://raw.githubusercontent.com/foontype/hype/main/src/hype"
-RELEASE_URL="https://github.com/foontype/hype/releases/download"
+REPO_OWNER="${HYPE_REPO_OWNER:-foontype}"
+REPO_NAME="${HYPE_REPO_NAME:-hype}"
+REPO_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/src/hype"
+RELEASE_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download"
 
 # Colors for output
 RED='\033[0;31m'

--- a/src/hype
+++ b/src/hype
@@ -817,7 +817,9 @@ cmd_upgrade() {
     fi
     
     # Get latest release information from GitHub API
-    local api_url="https://api.github.com/repos/foontype/hype/releases/latest"
+    local repo_owner="${HYPE_REPO_OWNER:-foontype}"
+    local repo_name="${HYPE_REPO_NAME:-hype}"
+    local api_url="https://api.github.com/repos/${repo_owner}/${repo_name}/releases/latest"
     local release_info
     
     if [[ "$download_tool" == "curl" ]]; then

--- a/src/hype
+++ b/src/hype
@@ -90,6 +90,7 @@ Usage:
   hype <hype-name> trait set <trait-type>                       Set trait type
   hype <hype-name> trait unset                                   Remove trait
   hype <hype-name> helmfile <helmfile-options>                  Run helmfile command
+  hype upgrade                                                   Upgrade HYPE CLI to latest version
   hype --version                                                 Show version
   hype --help                                                    Show this help
 
@@ -114,6 +115,7 @@ Examples:
   hype my-nginx helmfile apply                                   Apply helmfile for my-nginx
   hype my-nginx check                                            Check resource status
   hype my-nginx deinit                                           Remove all resources
+  hype upgrade                                                   Upgrade to latest HYPE CLI version
 
 EOF
 }
@@ -800,6 +802,132 @@ cmd_trait() {
     esac
 }
 
+# Self-upgrade command
+cmd_upgrade() {
+    info "Checking for HYPE CLI updates..."
+    
+    # Check if curl or wget is available
+    local download_tool=""
+    if command -v curl >/dev/null 2>&1; then
+        download_tool="curl"
+    elif command -v wget >/dev/null 2>&1; then
+        download_tool="wget"
+    else
+        die "Neither curl nor wget found. Please install one of them to use upgrade functionality."
+    fi
+    
+    # Get latest release information from GitHub API
+    local api_url="https://api.github.com/repos/foontype/hype/releases/latest"
+    local release_info
+    
+    if [[ "$download_tool" == "curl" ]]; then
+        if ! release_info=$(curl -s "$api_url"); then
+            die "Failed to fetch release information from GitHub API"
+        fi
+    else
+        if ! release_info=$(wget -qO- "$api_url"); then
+            die "Failed to fetch release information from GitHub API"
+        fi
+    fi
+    
+    # Extract latest version and download URL
+    local latest_version download_url
+    if ! command -v jq >/dev/null 2>&1; then
+        # Fallback parsing without jq (basic regex)
+        latest_version=$(echo "$release_info" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+        download_url=$(echo "$release_info" | grep '"browser_download_url".*hype"' | head -1 | sed 's/.*"browser_download_url": *"\([^"]*\)".*/\1/')
+    else
+        latest_version=$(echo "$release_info" | jq -r '.tag_name')
+        download_url=$(echo "$release_info" | jq -r '.assets[] | select(.name == "hype") | .browser_download_url')
+    fi
+    
+    if [[ -z "$latest_version" || -z "$download_url" ]]; then
+        die "Failed to extract version or download URL from GitHub API response"
+    fi
+    
+    # Remove 'v' prefix from version for comparison
+    latest_version_clean="${latest_version#v}"
+    
+    debug "Current version: $HYPE_VERSION"
+    debug "Latest version: $latest_version_clean"
+    debug "Download URL: $download_url"
+    
+    # Compare versions
+    if [[ "$HYPE_VERSION" == "$latest_version_clean" ]]; then
+        info "HYPE CLI is already up to date (version $HYPE_VERSION)"
+        return 0
+    fi
+    
+    info "New version available: $latest_version_clean (current: $HYPE_VERSION)"
+    info "Downloading update from: $download_url"
+    
+    # Determine the path of the current script
+    local script_path
+    script_path=$(readlink -f "${BASH_SOURCE[0]}")
+    local backup_path="${script_path}.backup"
+    
+    debug "Script path: $script_path"
+    debug "Backup path: $backup_path"
+    
+    # Create backup of current version
+    if ! cp "$script_path" "$backup_path"; then
+        die "Failed to create backup of current version"
+    fi
+    
+    info "Created backup: $backup_path"
+    
+    # Download new version to temporary file
+    local temp_file
+    temp_file=$(mktemp)
+    
+    if [[ "$download_tool" == "curl" ]]; then
+        if ! curl -L -o "$temp_file" "$download_url"; then
+            rm -f "$temp_file"
+            die "Failed to download new version"
+        fi
+    else
+        if ! wget -O "$temp_file" "$download_url"; then
+            rm -f "$temp_file"
+            die "Failed to download new version"
+        fi
+    fi
+    
+    # Verify download (basic check - file should not be empty and should be executable script)
+    if [[ ! -s "$temp_file" ]]; then
+        rm -f "$temp_file"
+        die "Downloaded file is empty"
+    fi
+    
+    # Check if it's a bash script
+    if ! head -1 "$temp_file" | grep -q "#!/bin/bash"; then
+        rm -f "$temp_file"
+        die "Downloaded file does not appear to be a valid bash script"
+    fi
+    
+    # Replace current script with new version
+    if ! cp "$temp_file" "$script_path"; then
+        # Restore from backup if replacement fails
+        cp "$backup_path" "$script_path"
+        rm -f "$temp_file"
+        die "Failed to replace script. Restored from backup."
+    fi
+    
+    # Set executable permissions
+    if ! chmod +x "$script_path"; then
+        # Restore from backup if chmod fails
+        cp "$backup_path" "$script_path"
+        rm -f "$temp_file"
+        die "Failed to set executable permissions. Restored from backup."
+    fi
+    
+    # Clean up
+    rm -f "$temp_file"
+    
+    info "Successfully updated HYPE CLI to version $latest_version_clean"
+    info "Backup of previous version saved as: $backup_path"
+    info "Run 'hype --version' to verify the update"
+}
+
 # Run helmfile command
 cmd_helmfile() {
     local hype_name="$1"
@@ -950,6 +1078,9 @@ main() {
             ;;
         "--version"|"-v")
             show_version
+            ;;
+        "upgrade")
+            cmd_upgrade
             ;;
         *)
             if [[ $# -lt 2 ]]; then


### PR DESCRIPTION
## Summary

この PR は HYPE CLI に自己アップグレード機能を追加します。

- **新しいコマンド**: `hype upgrade` を追加
- **GitHub API 統合**: 最新リリースを自動的に取得
- **安全なアップグレード**: バックアップ作成とロールバック機能
- **柔軟な依存関係**: curl/wget の両方をサポート、jq なしでも動作

## Test plan

- [x] `shellcheck` でスクリプト検証完了
- [x] `hype --help` でコマンドが表示されることを確認
- [x] `hype upgrade` コマンドの基本構文が正しく動作
- [ ] 実際のアップグレード動作テスト（次のリリース後）

## 実装詳細

### コマンド仕様
```bash
hype upgrade  # 最新バージョンにアップグレード
```

### 主な機能
- GitHub Releases API から最新バージョンを取得
- 現在のバージョンと比較して更新が必要か判定
- ダウンロード前に現在のスクリプトをバックアップ
- ダウンロードしたファイルの基本検証（非空、bash スクリプト）
- アップグレード失敗時の自動ロールバック
- 実行権限の適切な維持

### 技術的考慮事項
- `curl` または `wget` を使用（どちらでも対応）
- `jq` がある場合は使用、ない場合は regex フォールバック
- `readlink -f` でスクリプト自身のパスを正確に取得
- 一時ファイルの安全な処理とクリーンアップ

🤖 Generated with [Claude Code](https://claude.ai/code)