### PR TITLE
Release version 0.5.1

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,35 @@
+"v0.5.1": |
+  ## What's New in HYPE CLI v0.5.1
+
+  ### New Features
+  - **Self-Upgrade Functionality**: Added `hype upgrade` command for automatic CLI updates
+    - Automatically downloads and installs the latest version from GitHub releases
+    - Creates backup of current version before upgrade for safety
+    - Validates download integrity and script format before installation
+    - Supports both curl and wget for download operations
+    - Version comparison to prevent unnecessary upgrades
+
+  ### Improvements
+  - **Environment Variable Configuration**: Replaced hardcoded foontype/hype URLs with configurable environment variables
+    - Added `HYPE_REPO_OWNER` and `HYPE_REPO_NAME` environment variables for repository customization
+    - Improves flexibility for forked or custom repositories
+    - Maintains backward compatibility with default foontype/hype repository
+
+  ### Technical Changes
+  - Version bump to 0.5.1
+  - Added `cmd_upgrade()` function with comprehensive download and installation logic
+  - Enhanced error handling and validation for upgrade process
+  - Added backup and restore functionality for failed upgrades
+  - Improved GitHub API integration for release information fetching
+
+  ### Dependencies
+  - Bash 4.0+
+  - kubectl (for trait ConfigMap management)
+  - helmfile (for deployment operations)
+  - yq (mikefarah version)
+  - helm-diff plugin
+  - curl or wget (for upgrade functionality)
+
 "v0.5.0": |
   ## What's New in HYPE CLI v0.5.0
 

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.5.0"
+HYPE_VERSION="0.5.1"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 
 # Colors for output


### PR DESCRIPTION
## Summary
Release version 0.5.1 with self-upgrade functionality and environment variable improvements.

### Changes
- **Version Update**: Update HYPE_VERSION to 0.5.1 in src/hype
- **Release Notes**: Add comprehensive release notes for v0.5.1 including:
  - Self-upgrade functionality with `hype upgrade` command
  - Environment variable configuration for repository URLs (`HYPE_REPO_OWNER`, `HYPE_REPO_NAME`)
  - Enhanced error handling and backup functionality

### New Features in v0.5.1
- **Self-Upgrade Command**: Automatic CLI updates from GitHub releases with backup and validation
- **Configurable Repository URLs**: Support for custom repositories via environment variables
- **Improved Error Handling**: Better validation and recovery for upgrade process

## Test plan
- [ ] Verify version number updated to 0.5.1 in src/hype
- [ ] Validate release notes format and content
- [ ] Test hype upgrade functionality (post-release)
- [ ] Confirm environment variable configuration works

🤖 Generated with [Claude Code](https://claude.ai/code)