### PR TITLE
Reverse StateValuesConfigmap processing order for priority control

### DIFF
--- a/src/hype
+++ b/src/hype
@@ -1019,8 +1019,9 @@ EOF
             fi
         done
         
-        # Second pass: Process StateValuesConfigmap resources
-        for (( i=0; i<resource_count; i++ )); do
+        # Second pass: Process StateValuesConfigmap resources in reverse order
+        # (later resources in hypefile get higher priority in state-values-file)
+        for (( i=resource_count-1; i>=0; i-- )); do
             local name type
             
             name=$(yq eval ".defaultResources[$i].name" "$HYPE_SECTION_FILE" | sed "s/{{ \.Hype\.Name }}/$hype_name/g" | sed "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g")


### PR DESCRIPTION
## Summary
- Process StateValuesConfigmap resources in reverse order (later in hypefile processed first)
- Later resources in hypefile now get higher priority in --state-values-file arguments
- Add comments explaining the priority behavior

## Changes
- Modified `cmd_helmfile` function in `src/hype` to process StateValuesConfigmap resources in reverse order
- Changed loop from `for (( i=0; i<resource_count; i++ ))` to `for (( i=resource_count-1; i>=0; i-- ))`
- Added explanatory comments about priority behavior

## Test plan
- [ ] Test with multiple StateValuesConfigmap resources in hypefile
- [ ] Verify that later resources override values from earlier resources
- [ ] Ensure DefaultStateValues processing remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)