### PR TITLE
Add smoke testing documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,17 @@ shellcheck install.sh
 shellcheck .devcontainer/post-create-command.sh
 ```
 
+### Smoke Testing
+```bash
+# Run comprehensive smoke test following .claude/test.md
+# Note: This test should be run from the examples/nginx directory
+# and requires kubectl and helmfile to be properly configured
+
+# Follow the complete test sequence in .claude/test.md for smoke testing
+# This covers trait management, parsing, initialization, templating,
+# and deployment/destruction workflows
+```
+
 ### Development Installation
 ```bash
 # Test the install script locally


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add comprehensive smoke testing section to CLAUDE.md
- Reference .claude/test.md for thorough testing workflow
- Document prerequisites (kubectl and helmfile configuration)

## Test plan
- [x] Verify CLAUDE.md formatting is correct
- [x] Confirm smoke testing section is added in appropriate location
- [x] Ensure documentation follows existing style conventions

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)