### PR TITLE
Limit template variable replacement to hype section only

### DIFF
--- a/src/hype
+++ b/src/hype
@@ -163,22 +163,18 @@ parse_hypefile() {
     section == "taskfile" { print > taskfile_file }
     ' "$HYPEFILE"
     
-    # Replace template variables with actual values (hype and helmfile sections only)
+    # Replace template variables with actual values (hype section only)
     sed -i "s/{{ \.Hype\.Name }}/$hype_name/g" "$HYPE_SECTION_FILE"
-    sed -i "s/{{ \.Hype\.Name }}/$hype_name/g" "$HELMFILE_SECTION_FILE"
     sed -i "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g" "$HYPE_SECTION_FILE"
-    sed -i "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g" "$HELMFILE_SECTION_FILE"
     
-    # Replace {{ .Hype.Trait }} with actual trait value (hype and helmfile sections only)
+    # Replace {{ .Hype.Trait }} with actual trait value (hype section only)
     local trait_value
     if trait_value=$(get_hype_trait "$hype_name" 2>/dev/null); then
         debug "Found trait for template replacement: $trait_value"
         sed -i "s/{{ \.Hype\.Trait }}/$trait_value/g" "$HYPE_SECTION_FILE"
-        sed -i "s/{{ \.Hype\.Trait }}/$trait_value/g" "$HELMFILE_SECTION_FILE"
     else
         debug "No trait found, removing trait template variables"
         sed -i "s/{{ \.Hype\.Trait }}//g" "$HYPE_SECTION_FILE"
-        sed -i "s/{{ \.Hype\.Trait }}//g" "$HELMFILE_SECTION_FILE"
     fi
     
     # Note: TASKFILE_SECTION_FILE is not processed here - it keeps its original template variables


### PR DESCRIPTION
## Summary
- Remove template variable replacement from helmfile section
- Keep template variable replacement only in hype section
- Improve consistency across section processing

## Changes
- `{{ .Hype.Name }}`, `{{ .Hype.CurrentDirectory }}`, `{{ .Hype.Trait }}` replacement now limited to hype section only
- Helmfile section preserves template variables for helmfile's own processing
- Taskfile section behavior unchanged (uses environment variables)

## Motivation
This eliminates the inconsistency where some sections had direct template replacement while others used environment variables, providing a cleaner separation of concerns.

🤖 Generated with [Claude Code](https://claude.ai/code)