### PR TITLE
Fix task execution directory

### DIFF
--- a/src/hype
+++ b/src/hype
@@ -1019,7 +1019,11 @@ cmd_task() {
     
     debug "Set environment variables - HYPE_NAME: $hype_name, HYPE_CURRENT_DIRECTORY: $(pwd)"
     
-    # Run task with the temporary taskfile
+    # Get hype project directory from hypefile location
+    local hype_project_dir
+    hype_project_dir=$(dirname "$HYPEFILE_PATH")
+    
+    # Run task with the temporary taskfile in the hype project directory
     local cmd=("task" "--taskfile" "$TASKFILE_SECTION_FILE" "$task_name")
     
     # Add user-provided arguments
@@ -1027,8 +1031,10 @@ cmd_task() {
         cmd+=("--" "${task_args[@]}")
     fi
     
-    debug "Executing: ${cmd[*]}"
-    "${cmd[@]}"
+    debug "Executing: ${cmd[*]} (in directory: $hype_project_dir)"
+    
+    # Change to hype project directory and execute task
+    (cd "$hype_project_dir" && "${cmd[@]}")
 }
 
 # Run helmfile command


### PR DESCRIPTION
## Summary
- Fix task command execution to run in the correct hype project directory
- Resolves issue where tasks were running in the wrong working directory

## Changes
- Modified `cmd_task()` function to change to hype project directory before executing tasks
- Use subshell `(cd "$hype_project_dir" && "${cmd[@]}")` to ensure proper directory context
- Derive hype project directory from `HYPEFILE_PATH` location
- Enhanced debug logging to show execution directory

## Test plan
- [ ] Test task execution with relative paths in taskfile
- [ ] Verify tasks run in correct directory context
- [ ] Check that environment variables are still properly set