### PR TITLE
Update version to 0.5.3

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,28 @@
+"v0.5.3": |
+  ## What's New in HYPE CLI v0.5.3
+
+  ### Improvements
+  - **Template Variable Scope Enhancement**: Limited template variable replacement to hype section only
+    - Template variables like `{{ .Hype.Name }}`, `{{ .Hype.CurrentDirectory }}`, and `{{ .Hype.Trait }}` are now replaced only in the hype section
+    - Prevents unintended variable replacement in helmfile and taskfile sections where Go templating should be preserved
+    - Improves compatibility with helmfile's Go template processing
+    - Better separation of concerns between HYPE CLI preprocessing and Go template rendering
+
+  ### Technical Changes
+  - Version bump to 0.5.3
+  - Enhanced `parse_hypefile()` function to limit template replacement scope
+  - Improved template variable processing logic for better section isolation
+  - Maintains backward compatibility for existing hypefile configurations
+
+  ### Dependencies
+  - Bash 4.0+
+  - kubectl (for trait ConfigMap management)
+  - helmfile (for deployment operations)
+  - yq (mikefarah version)
+  - helm-diff plugin
+  - go-task (for taskfile integration)
+  - curl or wget (for upgrade functionality)
+
 "v0.5.2": |
   ## What's New in HYPE CLI v0.5.2
 

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.5.2"
+HYPE_VERSION="0.5.3"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 
 # Colors for output


### PR DESCRIPTION
## Summary
- Update HYPE CLI version to 0.5.3
- Add comprehensive release notes for v0.5.3

## Changes
- **Version Update**: Updated `HYPE_VERSION` in `src/hype` script from 0.5.2 to 0.5.3
- **Release Notes**: Added detailed release notes for v0.5.3 covering template variable scope enhancements

## Key Improvements in v0.5.3
- **Template Variable Scope Enhancement**: Limited template variable replacement to hype section only
- Better separation of concerns between HYPE CLI preprocessing and Go template rendering
- Improved compatibility with helmfile's Go template processing

🤖 Generated with [Claude Code](https://claude.ai/code)