### PR TITLE
Fix HYPEFILE_PATH undefined variable in task execution

### DIFF
--- a/src/hype
+++ b/src/hype
@@ -1027,10 +1027,10 @@ cmd_task() {
         cmd+=("--" "${task_args[@]}")
     fi
     
-    debug "Executing: ${cmd[*]} (in directory: $(dirname "$HYPEFILE_PATH"))"
+    debug "Executing: ${cmd[*]} (in directory: $HYPE_CURRENT_DIRECTORY)"
     
     # Change to hype project directory and execute task
-    (cd "$(dirname "$HYPEFILE_PATH")" && "${cmd[@]}")
+    (cd "$HYPE_CURRENT_DIRECTORY" && "${cmd[@]}")
 }
 
 # Run helmfile command


### PR DESCRIPTION
## Summary
- Fixed undefined `HYPEFILE_PATH` variable causing errors on lines 1030 and 1033
- Replaced with correct `HYPE_CURRENT_DIRECTORY` variable in task command execution
- Resolves unbound variable errors in `hype test task vars` command

## Test plan
- [x] Verified the fix resolves the HYPEFILE_PATH unbound variable error
- [x] Confirmed task execution now uses correct working directory
- [x] Smoke tested other hype commands to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)