### PR TITLE
Fix task execution directory issue by using --dir option

### DIFF
--- a/src/hype
+++ b/src/hype
@@ -1020,7 +1020,7 @@ cmd_task() {
     debug "Set environment variables - HYPE_NAME: $hype_name, HYPE_CURRENT_DIRECTORY: $(pwd)"
     
     # Run task with the temporary taskfile in the hype project directory
-    local cmd=("task" "--taskfile" "$TASKFILE_SECTION_FILE" "$task_name")
+    local cmd=("task" "--taskfile" "$TASKFILE_SECTION_FILE" "--dir" "$HYPE_CURRENT_DIRECTORY" "$task_name")
     
     # Add user-provided arguments
     if [[ ${#task_args[@]} -gt 0 ]]; then
@@ -1029,8 +1029,8 @@ cmd_task() {
     
     debug "Executing: ${cmd[*]} (in directory: $HYPE_CURRENT_DIRECTORY)"
     
-    # Change to hype project directory and execute task
-    (cd "$HYPE_CURRENT_DIRECTORY" && "${cmd[@]}")
+    # Execute task with --dir option
+    "${cmd[@]}"
 }
 
 # Run helmfile command


### PR DESCRIPTION
## Summary
- Replace `cd` subshell with `task --dir` option to prevent working directory corruption
- Ensures HYPE_CURRENT_DIRECTORY remains accurate throughout task execution process  
- Fixes issue where task commands were executed in wrong directory (/tmp instead of project directory)

## Changes
- Modified `cmd_task()` function in `src/hype` to use `--dir` option instead of `cd` subshell
- Removed problematic `(cd "$HYPE_CURRENT_DIRECTORY" && "${cmd[@]}")` pattern
- Added `--dir "$HYPE_CURRENT_DIRECTORY"` to task command arguments

## Test plan
- ✅ Verified `hype test task vars` executes successfully without directory errors
- ✅ Confirmed HYPE_CURRENT_DIRECTORY environment variable is set correctly
- ✅ Checked that `pwd` returns correct directory during task execution
- ✅ Ensured task commands can access hypefile.yaml properly

🤖 Generated with [Claude Code](https://claude.ai/code)