### PR TITLE
Release v0.5.4 - Fix task execution directory issues

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,32 @@
+"v0.5.4": |
+  ## What's New in HYPE CLI v0.5.4
+
+  ### Bug Fixes
+  - **Task Execution Directory Fixes**: Fixed critical issues with working directory handling during task execution
+    - Replaced directory change (`cd`) with `--dir` option in task execution to prevent working directory corruption
+    - Fixed HYPEFILE_PATH undefined variable errors by using HYPE_CURRENT_DIRECTORY consistently
+    - Improved task execution reliability and directory state management
+
+  ### Improvements
+  - **Enhanced Task Runner Integration**: Better integration with go-task runner using proper directory options
+  - **Variable Consistency**: Standardized environment variable naming across task execution functions
+  - **Error Prevention**: Eliminated unbound variable errors that could occur during task execution
+
+  ### Technical Changes
+  - Version bump to 0.5.4
+  - Updated task execution command to use `--dir` option instead of directory changes
+  - Fixed variable references in task execution functions (lines 1030 and 1033)
+  - Enhanced working directory preservation during task operations
+
+  ### Dependencies
+  - Bash 4.0+
+  - kubectl (for trait ConfigMap management)
+  - helmfile (for deployment operations)
+  - yq (mikefarah version)
+  - helm-diff plugin
+  - go-task (for taskfile integration)
+  - curl or wget (for upgrade functionality)
+
 "v0.5.3": |
   ## What's New in HYPE CLI v0.5.3
 

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.5.3"
+HYPE_VERSION="0.5.4"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 
 # Colors for output


### PR DESCRIPTION
## Summary

This release addresses critical issues with task execution directory handling and variable references:

- **Fixed task execution directory corruption** by replacing `cd` with `--dir` option in task execution
- **Resolved HYPEFILE_PATH undefined variable errors** by using consistent HYPE_CURRENT_DIRECTORY variable
- **Enhanced working directory preservation** during task operations

## Changes

- Updated version from 0.5.3 to 0.5.4 in `src/hype`
- Added comprehensive release notes for v0.5.4 in `release-notes.yaml`

## Testing

This release resolves issues that were preventing reliable task execution, particularly in CI/CD environments and when running tasks from different directories.

🤖 Generated with [Claude Code](https://claude.ai/code)