### PR TITLE
Release version 0.5.6

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,27 @@
+"v0.5.6": |
+  ## What's New in HYPE CLI v0.5.6
+
+  ### Improvements
+  - **Enhanced Logging Control**: Further improvements to the silent proxy method for better external command execution
+    - Enhanced the `silent()` function to properly handle external tool output without HYPE log interference
+    - Improved integration with task and helmfile commands for cleaner output
+    - Better preservation of original HYPE_LOG settings during command execution
+
+  ### Technical Changes
+  - Version bump to 0.5.6
+  - Updated hypefile.yaml configuration examples
+  - Enhanced logging proxy functionality for external command integration
+  - Improved silent execution method implementation
+
+  ### Dependencies
+  - Bash 4.0+
+  - kubectl (for trait ConfigMap management)
+  - helmfile (for deployment operations)
+  - yq (mikefarah version)
+  - helm-diff plugin
+  - go-task (for taskfile integration)
+  - curl or wget (for upgrade functionality)
+
 "v0.5.5": |
   ## What's New in HYPE CLI v0.5.5
 

--- a/src/hype
+++ b/src/hype
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-HYPE_VERSION="0.5.5"
+HYPE_VERSION="0.5.6"
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"
 HYPE_LOG="${HYPE_LOG:-stdout}"
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Bump version to 0.5.6 in src/hype script
- Add comprehensive v0.5.6 release notes to release-notes.yaml
- Document enhanced logging control improvements

## Changes
- **Version Update**: Updated `HYPE_VERSION` from 0.5.5 to 0.5.6
- **Release Notes**: Added detailed v0.5.6 release notes highlighting logging control enhancements
- **Documentation**: Enhanced documentation for silent proxy method improvements

## Test plan
- [ ] Verify version displays correctly with `./src/hype --version`
- [ ] Confirm release notes are properly formatted in YAML
- [ ] Test logging functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)