### PR TITLE
Fix release workflow for v0.6.0 plugin architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,22 +16,26 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Install ShellCheck
+    - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y shellcheck
         
-    - name: Run tests
-      run: |
-        shellcheck src/hype
-        shellcheck install.sh
-        shellcheck .devcontainer/post-create-command.sh
+        # Install go-task
+        sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
         
-        chmod +x src/hype
+    - name: Build and test
+      run: |
+        # Build the project
+        task build
+        
+        # Run linting
+        task lint
         
         # Test commands
-        ./src/hype --help
-        ./src/hype --version
+        ./build/hype --help
+        ./build/hype --version
         
     - name: Install yq
       run: |
@@ -78,6 +82,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./src/hype
+        asset_path: ./build/hype
         asset_name: hype
         asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- Fix release workflow to work with new v0.6.0 plugin architecture
- Update build process to use go-task instead of expecting src/hype file
- Fix linting and testing commands for new project structure
- Update release asset path to use build/hype

## Changes
- Install go-task in CI environment
- Use `task build` to build the project
- Use `task lint` for code quality checks
- Test built binary at `./build/hype` location
- Upload `./build/hype` as release asset

This fixes the failed v0.6.0 release workflow that was looking for the old `src/hype` file.

🤖 Generated with [Claude Code](https://claude.ai/code)