### PR TITLE
Update README.md to include sudo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ HYPE is a Bash-based CLI tool that simplifies the deployment and management of K
 curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | bash
 ```
 
+For system-wide installation (installs to `/usr/local/bin`):
+```bash
+curl -sSL https://raw.githubusercontent.com/foontype/hype/main/install.sh | sudo bash
+```
+
 ### Install Specific Version
 
 You can install a specific version using the `INSTALL_VERSION` environment variable:


### PR DESCRIPTION
## Summary
- Add documentation for system-wide installation using sudo
- Clarify that sudo installation installs HYPE CLI to `/usr/local/bin`

## Changes
- Updated Quick Install section in README.md to include sudo installation option with clear explanation

This addresses user requests for clearer documentation on system-wide installation options.