### PR TITLE
Add deployment lifecycle aliases: up, down, restart

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -20,6 +20,9 @@ Usage:
   hype <hype-name> trait unset                                   Remove trait
   hype <hype-name> task <task-name> [args...]                   Run task from taskfile section
   hype <hype-name> helmfile <helmfile-options>                  Run helmfile command
+  hype <hype-name> up                                            Build and deploy (task build + helmfile apply)
+  hype <hype-name> down                                          Destroy deployment (helmfile destroy)
+  hype <hype-name> restart                                       Restart deployment (down + up)
   hype upgrade                                                   Upgrade HYPE CLI to latest version
   hype --version                                                 Show version
   hype --help                                                    Show this help
@@ -48,6 +51,9 @@ Examples:
   hype my-nginx trait set production                             Set trait to production
   hype my-nginx task deploy                                      Run deploy task
   hype my-nginx helmfile sync                                    Sync with helmfile
+  hype my-nginx up                                               Build and deploy my-nginx
+  hype my-nginx down                                             Destroy my-nginx deployment
+  hype my-nginx restart                                          Restart my-nginx deployment
 EOF
 }
 
@@ -118,6 +124,18 @@ main() {
                 "helmfile")
                     check_dependencies
                     cmd_helmfile "$hype_name" "$@"
+                    ;;
+                "up")
+                    check_dependencies
+                    cmd_up "$hype_name"
+                    ;;
+                "down")
+                    check_dependencies
+                    cmd_down "$hype_name"
+                    ;;
+                "restart")
+                    check_dependencies
+                    cmd_restart "$hype_name"
                     ;;
                 *)
                     error "Unknown command: $command"

--- a/src/plugins/aliases.sh
+++ b/src/plugins/aliases.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+# HYPE CLI Aliases Plugin
+# Handles deployment lifecycle aliases: up, down, restart
+
+# Plugin metadata
+PLUGIN_NAME="aliases"
+PLUGIN_VERSION="1.0.0"
+PLUGIN_DESCRIPTION="Deployment lifecycle aliases"
+PLUGIN_COMMANDS=("up" "down" "restart")
+
+# Check if build task exists in taskfile
+has_build_task() {
+    local hype_name="$1"
+    
+    if [[ ! -f "$TASKFILE_SECTION_FILE" || ! -s "$TASKFILE_SECTION_FILE" ]]; then
+        return 1
+    fi
+    
+    if ! command -v task >/dev/null 2>&1; then
+        return 1
+    fi
+    
+    if task --taskfile "$TASKFILE_SECTION_FILE" --list-all 2>/dev/null | grep -E "^\* build:" >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Run build task
+run_build_task() {
+    local hype_name="$1"
+    
+    info "Running build task for hype: $hype_name"
+    
+    # Set up environment variables for the task
+    export HYPE_NAME="$hype_name"
+    local current_dir
+    current_dir="$(pwd)"
+    export HYPE_CURRENT_DIRECTORY="$current_dir"
+    
+    # Set trait if available
+    local trait_value
+    if trait_value=$(get_hype_trait "$hype_name" 2>/dev/null); then
+        export HYPE_TRAIT="$trait_value"
+        debug "Set HYPE_TRAIT environment variable: $trait_value"
+    else
+        unset HYPE_TRAIT
+        debug "No trait set, HYPE_TRAIT environment variable unset"
+    fi
+    
+    # Run build task
+    local cmd=("task" "--taskfile" "$TASKFILE_SECTION_FILE" "--dir" "$HYPE_CURRENT_DIRECTORY" "build")
+    
+    debug "Executing build task: ${cmd[*]}"
+    "${cmd[@]}"
+}
+
+# Run helmfile apply
+run_helmfile_apply() {
+    local hype_name="$1"
+    
+    info "Running helmfile apply for hype: $hype_name"
+    cmd_helmfile "$hype_name" "apply"
+}
+
+# Run helmfile destroy
+run_helmfile_destroy() {
+    local hype_name="$1"
+    
+    info "Running helmfile destroy for hype: $hype_name"
+    cmd_helmfile "$hype_name" "destroy"
+}
+
+# Up command: build (if available) + helmfile apply
+cmd_up() {
+    local hype_name="$1"
+    
+    debug "Running up command for: $hype_name"
+    
+    parse_hypefile "$hype_name"
+    
+    # Run build task if available
+    if has_build_task "$hype_name"; then
+        debug "Build task found, running build"
+        if ! run_build_task "$hype_name"; then
+            error "Build task failed"
+            exit 1
+        fi
+        info "Build task completed successfully"
+    else
+        debug "No build task found, skipping build step"
+    fi
+    
+    # Run helmfile apply
+    if ! run_helmfile_apply "$hype_name"; then
+        error "Helmfile apply failed"
+        exit 1
+    fi
+    
+    info "Up command completed successfully for hype: $hype_name"
+}
+
+# Down command: helmfile destroy
+cmd_down() {
+    local hype_name="$1"
+    
+    debug "Running down command for: $hype_name"
+    
+    parse_hypefile "$hype_name"
+    
+    # Run helmfile destroy
+    if ! run_helmfile_destroy "$hype_name"; then
+        error "Helmfile destroy failed"
+        exit 1
+    fi
+    
+    info "Down command completed successfully for hype: $hype_name"
+}
+
+# Restart command: down + up
+cmd_restart() {
+    local hype_name="$1"
+    
+    debug "Running restart command for: $hype_name"
+    
+    parse_hypefile "$hype_name"
+    
+    # Run down first
+    info "Starting restart: running down phase"
+    if ! run_helmfile_destroy "$hype_name"; then
+        error "Down phase failed during restart"
+        exit 1
+    fi
+    
+    info "Down phase completed, starting up phase"
+    
+    # Run build task if available
+    if has_build_task "$hype_name"; then
+        debug "Build task found, running build"
+        if ! run_build_task "$hype_name"; then
+            error "Build task failed during restart"
+            exit 1
+        fi
+        info "Build task completed successfully"
+    else
+        debug "No build task found, skipping build step"
+    fi
+    
+    # Run up (helmfile apply)
+    if ! run_helmfile_apply "$hype_name"; then
+        error "Up phase failed during restart"
+        exit 1
+    fi
+    
+    info "Restart command completed successfully for hype: $hype_name"
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add new deployment lifecycle aliases for common workflow patterns
- Implement `up`, `down`, and `restart` commands as convenient shortcuts
- Provide seamless integration with existing build and helmfile workflows

## Changes
- **New aliases plugin** (`src/plugins/aliases.sh`):
  - `up`: Runs build task (if available) + helmfile apply
  - `down`: Runs helmfile destroy  
  - `restart`: Runs down + up sequence
- **Updated command routing** in `src/main.sh` 
- **Enhanced help text** with new command examples
- **Proper error handling** and logging for each workflow step

## Test plan
- [x] Build succeeds with `task build`
- [x] Linting passes with `task lint`
- [x] Help command shows new aliases correctly
- [ ] Test `up` command with existing hypefile
- [ ] Test `down` command functionality
- [ ] Test `restart` command flow
- [ ] Verify build task integration works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)