### PR TITLE
Update version to 0.6.2 and add release notes

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,39 @@
+"v0.6.2": |
+  ## What's New in HYPE CLI v0.6.2
+
+  ### Improvements
+  - **Deployment Lifecycle Management**: Added convenient deployment lifecycle aliases
+    - Added `up`, `down`, and `restart` aliases for better deployment workflow
+    - Enhanced deployment lifecycle management capabilities
+    - Improved user experience with intuitive command aliases
+
+  ### Bug Fixes
+  - **Task Variables Command**: Fixed yq parsing error in task vars command
+    - Resolved parsing issues that could occur with complex task variable structures
+    - Improved reliability of task variable processing
+    - Enhanced error handling for task configuration parsing
+
+  ### Documentation
+  - **Project Documentation Updates**: Enhanced project documentation and structure
+    - Updated test.md and other documentation files
+    - Improved development guidance and project instructions
+    - Better documentation for contributors and users
+
+  ### Technical Changes
+  - Version bump to 0.6.2
+  - Fixed yq parsing error handling in task variable processing
+  - Enhanced deployment lifecycle command aliases (up, down, restart)
+  - Improved documentation structure and content
+
+  ### Dependencies
+  - Bash 4.0+
+  - kubectl (for trait ConfigMap management)
+  - helmfile (for deployment operations)
+  - yq (mikefarah version)
+  - helm-diff plugin
+  - go-task (for build system)
+  - curl or wget (for upgrade functionality)
+
 "v0.6.1": |
   ## What's New in HYPE CLI v0.6.1
 

--- a/src/core/config.sh
+++ b/src/core/config.sh
@@ -4,7 +4,7 @@
 # Core configuration settings and environment variables
 
 # Version information
-HYPE_VERSION="0.6.1"
+HYPE_VERSION="0.6.2"
 
 # Default configuration
 HYPEFILE="${HYPEFILE:-hypefile.yaml}"


### PR DESCRIPTION
## Summary
This PR updates HYPE CLI to version 0.6.2 with the following changes:

### Version Update
- Updated `HYPE_VERSION` from "0.6.1" to "0.6.2" in `src/core/config.sh`

### Release Notes Added
- Added comprehensive release notes for v0.6.2 in `release-notes.yaml`
- Documented deployment lifecycle aliases (up, down, restart)
- Documented fix for yq parsing error in task vars command
- Documented documentation updates and improvements

### Changes Included
- **Deployment Lifecycle Management**: Added convenient deployment lifecycle aliases
- **Task Variables Command**: Fixed yq parsing error
- **Documentation**: Enhanced project documentation and structure

## Test Plan
- [ ] Verify version update in `src/core/config.sh`
- [ ] Verify release notes format in `release-notes.yaml`
- [ ] Build and test the CLI: `task build && task test`
- [ ] Verify version output: `./build/hype --version`

🤖 Generated with [Claude Code](https://claude.ai/code)