### PR TITLE
Remove unused skip_hypefile_check variable

### DIFF
--- a/src/core/common.sh
+++ b/src/core/common.sh
@@ -9,6 +9,15 @@ HYPE_VERSION="0.6.2"
 # Initialize logging variable early to avoid unbound variable errors
 HYPE_LOG="${HYPE_LOG:-stdout}"
 
+# Debug and trace modes (initialize early)
+DEBUG="${DEBUG:-false}"
+TRACE="${TRACE:-false}"
+
+# Enable trace mode if requested
+if [[ "$TRACE" == "true" ]]; then
+    set -x
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/src/core/config.sh
+++ b/src/core/config.sh
@@ -27,45 +27,26 @@ if [[ "$TRACE" == "true" ]]; then
     set -x
 fi
 
-# Skip hypefile checks for version and help commands
-skip_hypefile_check=false
-if [[ $# -eq 0 ]]; then
-    skip_hypefile_check=true
-else
-    for arg in "$@"; do
-        if [[ "$arg" == "--version" || "$arg" == "-v" || "$arg" == "--help" || "$arg" == "-h" ]]; then
-            skip_hypefile_check=true
-            break
-        fi
-    done
-fi
-
 # Default configuration
 # Try to find hypefile.yaml by searching upward from current directory
-if [[ "$skip_hypefile_check" == "false" ]]; then
-    if [[ -z "${HYPEFILE:-}" ]]; then
-        if HYPEFILE=$(find_hypefile 2>/dev/null); then
-            debug "Found hypefile at: $HYPEFILE"
-        else
-            echo "Error: hypefile.yaml not found in current or parent directories" >&2
-            exit 1
-        fi
+if [[ -z "${HYPEFILE:-}" ]]; then
+    if HYPEFILE=$(find_hypefile 2>/dev/null); then
+        debug "Found hypefile at: $HYPEFILE"
     else
-        debug "Using specified HYPEFILE: $HYPEFILE"
-    fi
-
-    # Verify hypefile exists and set HYPE_DIR
-    if [[ -f "$HYPEFILE" ]]; then
-        HYPE_DIR=$(dirname "$(realpath "$HYPEFILE")")
-        export HYPE_DIR
-        debug "Set HYPE_DIR to hypefile directory: $HYPE_DIR"
-    else
-        echo "Error: hypefile not found at: $HYPEFILE" >&2
+        echo "Error: hypefile.yaml not found in current or parent directories" >&2
         exit 1
     fi
 else
-    # For version/help commands, set minimal defaults
-    HYPEFILE="${HYPEFILE:-hypefile.yaml}"
-    export HYPE_DIR="$PWD"
+    debug "Using specified HYPEFILE: $HYPEFILE"
+fi
+
+# Verify hypefile exists and set HYPE_DIR
+if [[ -f "$HYPEFILE" ]]; then
+    HYPE_DIR=$(dirname "$(realpath "$HYPEFILE")")
+    export HYPE_DIR
+    debug "Set HYPE_DIR to hypefile directory: $HYPE_DIR"
+else
+    echo "Error: hypefile not found at: $HYPEFILE" >&2
+    exit 1
 fi
 }

--- a/src/core/config.sh
+++ b/src/core/config.sh
@@ -18,15 +18,6 @@ find_hypefile() {
 
 # Configuration loading function
 load_config() {
-    # Debug and trace modes (initialize early)
-DEBUG="${DEBUG:-false}"
-TRACE="${TRACE:-false}"
-
-# Enable trace mode if requested
-if [[ "$TRACE" == "true" ]]; then
-    set -x
-fi
-
 # Default configuration
 # Try to find hypefile.yaml by searching upward from current directory
 if [[ -z "${HYPEFILE:-}" ]]; then


### PR DESCRIPTION
## Summary
- Remove unused `skip_hypefile_check` variable from config.sh
- Simplify config loading logic

## Background
The `skip_hypefile_check` flag was not serving any purpose since:
- `--version` and `--help` commands don't call `load_config` at all
- Other commands always need hypefile discovery functionality
- All tests pass without this variable

## Changes
- Removed `skip_hypefile_check` variable definition and logic
- Simplified conditional branching in config loading
- Maintained all existing functionality

## Test Results
- All 38 tests pass
- ShellCheck validation passes
- Build system works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)