### PR TITLE
feat: Add default HYPE_CACHE_DIR setting when hypefile.yaml is found

### DIFF
--- a/src/core/config.sh
+++ b/src/core/config.sh
@@ -36,6 +36,13 @@ load_config() {
         HYPE_DIR=$(dirname "$(realpath "$HYPEFILE")")
         export HYPE_DIR
         debug "Set HYPE_DIR to hypefile directory: $HYPE_DIR"
+        
+        # Set default HYPE_CACHE_DIR if not already defined
+        if [[ -z "${HYPE_CACHE_DIR:-}" ]]; then
+            HYPE_CACHE_DIR="${HYPE_DIR}/.hype"
+            export HYPE_CACHE_DIR
+            debug "Set HYPE_CACHE_DIR to default: $HYPE_CACHE_DIR"
+        fi
     else
         echo "Error: hypefile not found at: $HYPEFILE" >&2
         exit 1


### PR DESCRIPTION
## Summary
- Set `HYPE_CACHE_DIR` to `${HYPE_DIR}/.hype` when the environment variable is undefined
- Only sets default if `HYPE_CACHE_DIR` is not already defined, preserving existing configurations
- Added debug logging for cache directory configuration
- Maintains backward compatibility with existing setups

## Implementation Details
- Modified `src/core/config.sh:load_config()` function
- Added conditional check after `HYPE_DIR` is established from hypefile.yaml discovery
- Uses `${HYPE_CACHE_DIR:-}` parameter expansion to safely check for undefined variable
- Exports `HYPE_CACHE_DIR` and logs the configuration via debug output

## Test plan
- [x] Build passes with `task build`
- [x] Linting passes with `task lint`
- [x] No breaking changes to existing functionality
- [x] New functionality only activates when `HYPE_CACHE_DIR` is undefined

🤖 Generated with [Claude Code](https://claude.ai/code)