### PR TITLE
feat: Version bump to v0.6.3 with configuration improvements

### DIFF
--- a/release-notes.yaml
+++ b/release-notes.yaml
@@ -1,3 +1,43 @@
+"v0.6.3": |
+  ## What's New in HYPE CLI v0.6.3
+
+  ### Improvements
+  - **Configuration Management**: Fixed task vars command by correcting hype binary path
+    - Resolved path issues in task execution that could cause command failures
+    - Improved reliability of task variable processing
+    - Enhanced integration with go-task runner
+
+  ### Features  
+  - **Default Cache Directory**: Added automatic HYPE_CACHE_DIR setting when hypefile.yaml is found
+    - Automatically sets HYPE_CACHE_DIR to ${HYPE_DIR}/.hype when hypefile.yaml is detected
+    - Improves user experience by eliminating manual cache directory configuration
+    - Better default behavior for cache management
+
+  ### Documentation
+  - **Project Documentation Updates**: Updated test.md and hypefile.yaml configuration examples
+    - Enhanced documentation for better developer experience
+    - Improved configuration examples and testing procedures
+    - Updated project structure documentation
+
+  ### Bug Fixes
+  - **Task Execution**: Fixed binary path references in task execution workflow
+  - **Cache Directory Management**: Improved default cache directory initialization
+
+  ### Technical Changes
+  - Version bump to 0.6.3
+  - Enhanced find_hypefile function with better default HYPE_CACHE_DIR handling
+  - Fixed task command binary path resolution
+  - Improved configuration loading and directory management
+
+  ### Dependencies
+  - Bash 4.0+
+  - kubectl (for trait ConfigMap management)
+  - helmfile (for deployment operations)
+  - yq (mikefarah version)
+  - helm-diff plugin
+  - go-task (for build system)
+  - curl or wget (for upgrade functionality)
+
 "v0.6.2": |
   ## What's New in HYPE CLI v0.6.2
 

--- a/src/core/common.sh
+++ b/src/core/common.sh
@@ -4,7 +4,7 @@
 # Logging, utility functions, and color constants
 
 # Version information
-HYPE_VERSION="0.6.2"
+HYPE_VERSION="0.6.3"
 
 # Initialize logging variable early to avoid unbound variable errors
 HYPE_LOG="${HYPE_LOG:-stdout}"


### PR DESCRIPTION
## Summary
- Version bump from v0.6.2 to v0.6.3 in `src/core/common.sh`
- Added comprehensive release notes for v0.6.3 in `release-notes.yaml`

## Changes in v0.6.3

### Improvements
- **Configuration Management**: Fixed task vars command by correcting hype binary path
- **Default Cache Directory**: Added automatic HYPE_CACHE_DIR setting when hypefile.yaml is found

### Bug Fixes
- Fixed binary path references in task execution workflow
- Improved default cache directory initialization

### Documentation
- Updated test.md and hypefile.yaml configuration examples
- Enhanced project documentation and testing procedures

## Test Plan
- [ ] Build and test the CLI with `task build && task test`
- [ ] Verify version displays correctly with `./build/hype --version`
- [ ] Run smoke tests following `prompts/smoke-test.md`
- [ ] Test task vars command functionality
- [ ] Verify cache directory behavior

🤖 Generated with [Claude Code](https://claude.ai/code)