### PR TITLE
Add GitHub shorthand support for repo bind command

### DIFF
--- a/src/builtins/repo.sh
+++ b/src/builtins/repo.sh
@@ -25,7 +25,8 @@ Subcommands:
   info            Show repository binding information
 
 Examples:
-  hype my-nginx repo bind https://github.com/user/repo.git      Bind repository
+  hype my-nginx repo bind user/repo                              Bind repository (shorthand)
+  hype my-nginx repo bind https://github.com/user/repo.git      Bind repository (full URL)
   hype my-nginx repo info                                        Show binding info
   hype my-nginx repo unbind                                      Remove binding
 EOF
@@ -122,10 +123,20 @@ cmd_repo_bind() {
     branch="${branch:-main}"
     path="${path:-.}"
     
+    # Expand GitHub shorthand if applicable
+    local original_url="$repo_url"
+    repo_url=$(expand_github_shorthand "$repo_url")
+    
+    # Show expansion if shorthand was used
+    if [[ "$original_url" != "$repo_url" ]]; then
+        info "Expanding GitHub shorthand: $original_url -> $repo_url"
+    fi
+    
     # Validate repository URL
-    if ! validate_repo_url "$repo_url"; then
-        error "Invalid repository URL: $repo_url"
+    if ! validate_repo_url "$original_url"; then
+        error "Invalid repository URL: $original_url"
         error "Supported formats:"
+        error "  - user/repo (GitHub shorthand)"
         error "  - https://github.com/user/repo"
         error "  - https://github.com/user/repo.git"
         error "  - git@github.com:user/repo.git"
@@ -327,11 +338,14 @@ Options:
   --path <path>         Specify path within repository (default: .)
 
 Examples:
-  # Bind a GitHub repository
+  # Bind a GitHub repository using shorthand
+  hype myapp repo bind foontype/hype
+
+  # Bind a GitHub repository with full URL
   hype myapp repo bind https://github.com/user/repo.git
 
   # Bind with specific branch and path
-  hype myapp repo bind https://github.com/user/repo.git --branch develop --path deploy
+  hype myapp repo bind user/repo --branch develop --path deploy
 
   # Show binding information
   hype myapp repo

--- a/src/core/repo.sh
+++ b/src/core/repo.sh
@@ -127,9 +127,27 @@ has_repo_binding() {
     get_repo_binding "$hype_name" >/dev/null 2>&1
 }
 
+# Expand GitHub shorthand notation (user/repo) to full URL
+expand_github_shorthand() {
+    local url="$1"
+    
+    # Check if URL is GitHub shorthand (user/repo format)
+    if [[ "$url" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$ ]]; then
+        echo "https://github.com/${url}"
+        return 0
+    fi
+    
+    # Return original URL if not shorthand
+    echo "$url"
+    return 0
+}
+
 # Validate repository URL
 validate_repo_url() {
     local url="$1"
+    
+    # Expand GitHub shorthand if applicable
+    url=$(expand_github_shorthand "$url")
     
     # Basic URL validation
     if [[ ! "$url" =~ ^https?://.*\.git$ ]] && [[ ! "$url" =~ ^git@.*:.*\.git$ ]] && [[ ! "$url" =~ ^https?://github\.com/.*/.*$ ]]; then


### PR DESCRIPTION
## Summary
- GitHub省略記法 `user/repo` 形式のサポートを追加
- `hype myapp repo bind foontype/hype` のような使い方が可能に
- 既存の完全URL形式との互換性を維持

## Technical Changes
- Add `expand_github_shorthand()` function to convert `user/repo` format to full GitHub URL
- Update `validate_repo_url()` to handle GitHub shorthand notation  
- Modify `cmd_repo_bind()` to expand shorthand URLs and show expansion to user
- Update help messages and examples to include shorthand notation

## Test Plan
- [x] Test GitHub shorthand expansion: `foontype/hype` → `https://github.com/foontype/hype`
- [x] Test full URL passthrough unchanged
- [x] Test validation of invalid formats
- [x] Run ShellCheck linting - all passed
- [x] Build and basic functionality tests

## Examples
```bash
# New shorthand format
hype myapp repo bind foontype/hype

# Existing full URL format (still works)
hype myapp repo bind https://github.com/foontype/hype.git
```

🤖 Generated with [Claude Code](https://claude.ai/code)