### PR TITLE
Add Kubernetes-compliant hype name validation

### DIFF
--- a/src/core/config.sh
+++ b/src/core/config.sh
@@ -7,6 +7,33 @@
 declare -a BUILTIN_COMMANDS=()
 declare -A BUILTIN_HELP_FUNCTIONS=()
 
+# Validate hype name according to Kubernetes resource naming rules
+validate_hype_name() {
+    local name="$1"
+    
+    # Check if name is empty
+    if [[ -z "$name" ]]; then
+        error "Hype name cannot be empty"
+        return 1
+    fi
+    
+    # Check maximum length (253 characters for DNS compliance)
+    if [[ ${#name} -gt 253 ]]; then
+        error "Hype name '$name' is too long (max 253 characters)"
+        return 1
+    fi
+    
+    # Check if name matches Kubernetes resource naming rules
+    # Must start with lowercase letter, contain only lowercase letters, numbers, and hyphens
+    # Must not end with a hyphen
+    if [[ ! "$name" =~ ^[a-z]([a-z0-9-]*[a-z0-9])?$ ]]; then
+        error "Invalid hype name '$name'. Must start with a lowercase letter, contain only lowercase letters (a-z), numbers (0-9), and hyphens (-), and must not end with a hyphen."
+        return 1
+    fi
+    
+    return 0
+}
+
 # Find hypefile.yaml by searching upward from current directory
 find_hypefile() {
     local dir="$PWD"

--- a/src/main.sh
+++ b/src/main.sh
@@ -172,6 +172,13 @@ main() {
                 exit 1
             fi
             
+            # Validate hype name before proceeding (skip for upgrade command)
+            if [[ "$command" != "upgrade" ]]; then
+                if ! validate_hype_name "$hype_name"; then
+                    exit 1
+                fi
+            fi
+            
             load_config "$hype_name" "$command"
             
             debug "Command: $command, Hype name: $hype_name, Args: $*"

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -104,10 +104,10 @@ test_command_parsing() {
     # Create temporary directory with hypefile for testing
     local test_root
     test_root=$(mktemp -d)
-    echo "hype: testhype" > "$test_root/hypefile.yaml"
+    echo "hype: test-hype" > "$test_root/hypefile.yaml"
     
     # Test unknown command
-    output=$(cd "$test_root" && "$HYPE_BINARY" testhype unknown-command 2>&1) || true
+    output=$(cd "$test_root" && "$HYPE_BINARY" test-hype unknown-command 2>&1) || true
     if [[ "$output" =~ "Unknown command: unknown-command" ]]; then
         test_passed "Unknown command detection"
     else
@@ -115,7 +115,7 @@ test_command_parsing() {
     fi
     
     # Test missing arguments
-    output=$(cd "$test_root" && "$HYPE_BINARY" testhype 2>&1) || true
+    output=$(cd "$test_root" && "$HYPE_BINARY" test-hype 2>&1) || true
     if [[ "$output" =~ "Missing required arguments" ]]; then
         test_passed "Missing dependencies detection"
     else
@@ -230,12 +230,12 @@ test_hypefile_discovery() {
     echo "[DEBUG] Created test hypefile: $test_hypefile" >&2
     
     # Test 1: Find hypefile in current directory
-    echo "hype: testhype" > "$test_hypefile"
+    echo "hype: test-hype" > "$test_hypefile"
     echo "[DEBUG] Test 1: Starting hypefile discovery test from current directory" >&2
     
     # Add timeout to prevent hanging
     local test1_output
-    if test1_output=$(timeout 10s bash -c "cd '$test_root' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' testhype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test1_output" | grep -q "Found hypefile at: $test_hypefile"; then
+    if test1_output=$(timeout 10s bash -c "cd '$test_root' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' test-hype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test1_output" | grep -q "Found hypefile at: $test_hypefile"; then
         test_passed "Hypefile discovery: current directory"
     else
         echo "[DEBUG] Test 1 failed. Full output:" >&2
@@ -249,7 +249,7 @@ test_hypefile_discovery() {
     echo "[DEBUG] Test 2: Starting hypefile discovery test from subdirectory: $test_subdir" >&2
     
     local test2_output
-    if test2_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' testhype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test2_output" | grep -q "Found hypefile at: $test_hypefile"; then
+    if test2_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' test-hype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test2_output" | grep -q "Found hypefile at: $test_hypefile"; then
         test_passed "Hypefile discovery: parent directory search"
     else
         echo "[DEBUG] Test 2 failed. Full output:" >&2
@@ -263,7 +263,7 @@ test_hypefile_discovery() {
     echo "[DEBUG] Test 3: Testing error when no hypefile found in: $test_empty_root" >&2
     
     local error_output
-    error_output=$(timeout 5s bash -c "cd '$test_empty_root' && '$HYPE_BINARY' testhype init 2>&1") || true
+    error_output=$(timeout 5s bash -c "cd '$test_empty_root' && '$HYPE_BINARY' test-hype init 2>&1") || true
     if echo "$error_output" | grep -q "Error: hypefile.yaml not found in current or parent directories"; then
         test_passed "Hypefile discovery: error when not found"
     else
@@ -276,7 +276,7 @@ test_hypefile_discovery() {
     echo "[DEBUG] Test 4: Testing HYPE_DIR setting from subdirectory: $test_subdir" >&2
     
     local test4_output
-    if test4_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' testhype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test4_output" | grep -q "Set HYPE_DIR to hypefile directory: $test_root"; then
+    if test4_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' test-hype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test4_output" | grep -q "Set HYPE_DIR to hypefile directory: $test_root"; then
         test_passed "HYPE_DIR: set to hypefile directory"
     else
         echo "[DEBUG] Test 4 failed. Full output:" >&2

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -104,10 +104,10 @@ test_command_parsing() {
     # Create temporary directory with hypefile for testing
     local test_root
     test_root=$(mktemp -d)
-    echo "hype: test-hype" > "$test_root/hypefile.yaml"
+    echo "hype: testhype" > "$test_root/hypefile.yaml"
     
     # Test unknown command
-    output=$(cd "$test_root" && "$HYPE_BINARY" test-hype unknown-command 2>&1) || true
+    output=$(cd "$test_root" && "$HYPE_BINARY" testhype unknown-command 2>&1) || true
     if [[ "$output" =~ "Unknown command: unknown-command" ]]; then
         test_passed "Unknown command detection"
     else
@@ -115,7 +115,7 @@ test_command_parsing() {
     fi
     
     # Test missing arguments
-    output=$(cd "$test_root" && "$HYPE_BINARY" test-hype 2>&1) || true
+    output=$(cd "$test_root" && "$HYPE_BINARY" testhype 2>&1) || true
     if [[ "$output" =~ "Missing required arguments" ]]; then
         test_passed "Missing dependencies detection"
     else
@@ -230,12 +230,12 @@ test_hypefile_discovery() {
     echo "[DEBUG] Created test hypefile: $test_hypefile" >&2
     
     # Test 1: Find hypefile in current directory
-    echo "hype: test-hype" > "$test_hypefile"
+    echo "hype: testhype" > "$test_hypefile"
     echo "[DEBUG] Test 1: Starting hypefile discovery test from current directory" >&2
     
     # Add timeout to prevent hanging
     local test1_output
-    if test1_output=$(timeout 10s bash -c "cd '$test_root' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' test-hype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test1_output" | grep -q "Found hypefile at: $test_hypefile"; then
+    if test1_output=$(timeout 10s bash -c "cd '$test_root' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' testhype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test1_output" | grep -q "Found hypefile at: $test_hypefile"; then
         test_passed "Hypefile discovery: current directory"
     else
         echo "[DEBUG] Test 1 failed. Full output:" >&2
@@ -249,7 +249,7 @@ test_hypefile_discovery() {
     echo "[DEBUG] Test 2: Starting hypefile discovery test from subdirectory: $test_subdir" >&2
     
     local test2_output
-    if test2_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' test-hype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test2_output" | grep -q "Found hypefile at: $test_hypefile"; then
+    if test2_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' testhype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test2_output" | grep -q "Found hypefile at: $test_hypefile"; then
         test_passed "Hypefile discovery: parent directory search"
     else
         echo "[DEBUG] Test 2 failed. Full output:" >&2
@@ -263,7 +263,7 @@ test_hypefile_discovery() {
     echo "[DEBUG] Test 3: Testing error when no hypefile found in: $test_empty_root" >&2
     
     local error_output
-    error_output=$(timeout 5s bash -c "cd '$test_empty_root' && '$HYPE_BINARY' test-hype init 2>&1") || true
+    error_output=$(timeout 5s bash -c "cd '$test_empty_root' && '$HYPE_BINARY' testhype init 2>&1") || true
     if echo "$error_output" | grep -q "Error: hypefile.yaml not found in current or parent directories"; then
         test_passed "Hypefile discovery: error when not found"
     else
@@ -276,7 +276,7 @@ test_hypefile_discovery() {
     echo "[DEBUG] Test 4: Testing HYPE_DIR setting from subdirectory: $test_subdir" >&2
     
     local test4_output
-    if test4_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' test-hype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test4_output" | grep -q "Set HYPE_DIR to hypefile directory: $test_root"; then
+    if test4_output=$(timeout 10s bash -c "cd '$test_subdir' && env DEBUG=true HYPE_LOG=stdout '$HYPE_BINARY' testhype init 2>&1 | sed 's/\x1b\[[0-9;]*m//g'") && echo "$test4_output" | grep -q "Set HYPE_DIR to hypefile directory: $test_root"; then
         test_passed "HYPE_DIR: set to hypefile directory"
     else
         echo "[DEBUG] Test 4 failed. Full output:" >&2

--- a/tests/unit/test-config.sh
+++ b/tests/unit/test-config.sh
@@ -2,8 +2,9 @@
 
 # Unit tests for config module
 
-# Source the config module
-source "$(dirname "${BASH_SOURCE[0]}")/../src/core/config.sh"
+# Source the config module from proper path
+source "$(dirname "${BASH_SOURCE[0]}")/../../src/core/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../../src/core/config.sh"
 
 # Test version is set
 test_version_set() {
@@ -38,6 +39,54 @@ test_debug_default() {
     fi
 }
 
+# Test valid hype names
+test_valid_hype_names() {
+    local valid_names=("app" "my-app" "app123" "test-env-1" "a" "a1" "a-1" "web-server-prod")
+    local failed=0
+    
+    for name in "${valid_names[@]}"; do
+        if validate_hype_name "$name" 2>/dev/null; then
+            echo "✓ Valid hype name accepted: $name"
+        else
+            echo "✗ Valid hype name rejected: $name"
+            ((failed++))
+        fi
+    done
+    
+    return $failed
+}
+
+# Test invalid hype names
+test_invalid_hype_names() {
+    local invalid_names=("App" "1app" "app-" "-app" "app_test" "my@app" "" "APP" "test.app" "app/test")
+    local failed=0
+    
+    for name in "${invalid_names[@]}"; do
+        if ! validate_hype_name "$name" 2>/dev/null; then
+            echo "✓ Invalid hype name rejected: '$name'"
+        else
+            echo "✗ Invalid hype name accepted: '$name'"
+            ((failed++))
+        fi
+    done
+    
+    return $failed
+}
+
+# Test hype name length limit
+test_hype_name_length_limit() {
+    # Create a name longer than 253 characters
+    local long_name=$(printf 'a%.0s' {1..254})
+    
+    if ! validate_hype_name "$long_name" 2>/dev/null; then
+        echo "✓ Long hype name rejected (254 chars)"
+        return 0
+    else
+        echo "✗ Long hype name accepted (should be rejected)"
+        return 1
+    fi
+}
+
 # Run tests
 echo "Config Module Unit Tests"
 echo "========================"
@@ -45,5 +94,8 @@ echo "========================"
 test_version_set
 test_hypefile_default
 test_debug_default
+test_valid_hype_names
+test_invalid_hype_names
+test_hype_name_length_limit
 
 echo "Config tests completed"


### PR DESCRIPTION
## Summary
- Implement strict validation for hype names following Kubernetes resource naming rules
- Add comprehensive error handling with clear error messages  
- Include extensive unit tests for validation logic

## Changes
- **New function**: `validate_hype_name()` in `src/core/config.sh`
- **Validation rules**: Start with lowercase letter, contain only a-z/0-9/hyphens, max 253 chars
- **Integration**: Validation called in `src/main.sh` before command execution
- **Error handling**: Invalid names cause HYPE CLI to exit with descriptive error
- **Tests**: Added comprehensive test cases in `tests/unit/test-config.sh`

## Test plan
- [x] Unit tests pass for valid names: `app`, `my-app`, `app123`, `test-env-1`
- [x] Unit tests pass for invalid names: `App`, `1app`, `app-`, `app_test`, etc.
- [x] Integration tests confirm CLI exits with proper error messages
- [x] All existing tests continue to pass
- [x] ShellCheck validation passes

🤖 Generated with [Claude Code](https://claude.ai/code)