### PR TITLE
Fix trait default value template errors

### DIFF
--- a/src/builtins/helmfile.sh
+++ b/src/builtins/helmfile.sh
@@ -50,24 +50,16 @@ cmd_helmfile() {
     local current_dir_state_file
     current_dir_state_file=$(mktemp --suffix=.yaml)
     
-    # Get trait value if available
+    # Get trait value with default fallback
     local trait_value
-    if trait_value=$(get_hype_trait "$hype_name" 2>/dev/null); then
-        debug "Adding trait to state values: $trait_value"
-        cat > "$current_dir_state_file" << EOF
+    trait_value=$(get_hype_trait_with_default "$hype_name")
+    debug "Adding trait to state values: $trait_value"
+    cat > "$current_dir_state_file" << EOF
 Hype:
   CurrentDirectory: "$(pwd)"
   Name: "$hype_name"
   Trait: "$trait_value"
 EOF
-    else
-        debug "No trait found, using default state values"
-        cat > "$current_dir_state_file" << EOF
-Hype:
-  CurrentDirectory: "$(pwd)"
-  Name: "$hype_name"
-EOF
-    fi
     
     cmd+=("--state-values-file" "$current_dir_state_file")
     

--- a/src/builtins/trait.sh
+++ b/src/builtins/trait.sh
@@ -92,6 +92,20 @@ set_hype_trait() {
     info "Set trait '$trait_type' for hype: $hype_name"
 }
 
+# Get trait for hype name with default fallback
+get_hype_trait_with_default() {
+    local hype_name="$1"
+    local trait
+    
+    debug "Getting trait with default for hype: $hype_name"
+    
+    if trait=$(get_hype_trait "$hype_name" 2>/dev/null); then
+        echo "$trait"
+    else
+        echo "default"
+    fi
+}
+
 # Remove trait for hype name by deleting hype-trait-<hype-name> ConfigMap
 unset_hype_trait() {
     local hype_name="$1"


### PR DESCRIPTION
## Summary
- Fix template errors when `StateValues.Hype.Trait` is referenced but no trait is configured
- Add default trait value "default" when no explicit trait is set

## Changes
- Add `get_hype_trait_with_default()` function in `src/builtins/trait.sh`
- Update `src/builtins/helmfile.sh` to always include `Trait` key in state values
- Simplify state values generation logic

## Problem Solved
Previously, when running helmfile commands without a trait configured, template errors occurred:
```
map has no entry for key "Trait"
```

This happened because the state values YAML only included the `Trait` key when a trait was explicitly set, but templates expected it to always be present.

## Test plan
- [x] Build and test: `task build`
- [x] Verify trait default behavior: `hype test trait` shows "No trait set"
- [x] Verify state values include Trait: Debug output shows `Adding trait to state values: default`
- [x] Test helmfile commands work without errors when no trait is configured

🤖 Generated with [Claude Code](https://claude.ai/code)