### PR TITLE
Add repo validate subcommand

### DIFF
--- a/prompts/v0.7.0/test.md
+++ b/prompts/v0.7.0/test.md
@@ -126,6 +126,12 @@ task build を実行して build/hype をビルドします
   * バインド成功のメッセージが表示されること
   * kubectl でConfigMap hype-repos が作成されていること
 
+> ./build/hype myapp repo validate foontype/hype --path prompts/nginx-example
+  * $? が 0 を返すこと
+
+> ./build/hype myapp repo validate foontype/hype2
+  * $? が 1 を返すこと
+
 #### 4-1. バインドしたリポジトリの使用テスト
 
 > ./build/hype myapp parse section hype


### PR DESCRIPTION
## Summary
- Implement `hype <hype name> repo validate` subcommand
- Check if specified repository binding matches current configuration
- Silent operation with exit codes for scripting use

## Features
- Same argument parsing as `bind` command (`--branch`, `--path`, `repo_url`)
- Exit code 0 for match, exit code 1 for mismatch or no binding
- GitHub shorthand support (`user/repo` format)
- Comprehensive parameter validation (URL, branch, path)

## Usage Examples
```bash
# Basic validation
hype myapp repo validate foontype/hype

# Validate with specific branch and path
hype myapp repo validate user/repo --branch develop --path deploy

# Full URL validation
hype myapp repo validate https://github.com/user/repo.git
```

## Test plan
- [x] Built successfully with `task build`
- [x] Passed linting with `task lint`  
- [x] Help documentation updated
- [x] Exit code 1 when no binding exists
- [x] Argument parsing works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)