### PR TITLE
Refactor probe release to releases check command

### DIFF
--- a/prompts/v0.7.0/test.md
+++ b/prompts/v0.7.0/test.md
@@ -23,11 +23,11 @@ task build を実行して build/hype をビルドします
 > cd prompts/nginx-example
   * examples に移動します
 
-> cd prompts/nginx-example && ../../build/hype test probe release
+> cd prompts/nginx-example && ../../build/hype test releases check
   * $? が 1 であること
   * もし $? が 0 の場合（既存リソースが残っている場合）、以下を実行してリトライ:
     * `../../build/hype test down` でリソースをクリーンアップ
-    * 再度 `../../build/hype test probe release` を実行して $? が 1 であることを確認
+    * 再度 `../../build/hype test releases check` を実行して $? が 1 であることを確認
 
 > cd prompts/nginx-example && ../../build/hype test trait set test-trait
 
@@ -79,7 +79,7 @@ task build を実行して build/hype をビルドします
 > cd prompts/nginx-example && ../../build/hype test helmfile apply
   * kubectl から nginx がアップしていることを確認する
 
-> cd prompts/nginx-example && ../../build/hype test probe release
+> cd prompts/nginx-example && ../../build/hype test releases check
   * $? が 0 であること（リリースがデプロイされているため）
   * "All releases are present" メッセージが表示されること
 

--- a/src/builtins/releases.sh
+++ b/src/builtins/releases.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# HYPE CLI Probe Builtin
+# HYPE CLI Releases Builtin
 # 
-# This builtin provides probing capabilities for various HYPE components
+# This builtin provides release management capabilities for HYPE components
 
 # Builtin metadata (required)
-BUILTIN_NAME="probe"
+BUILTIN_NAME="releases"
 BUILTIN_VERSION="1.0.0"
-BUILTIN_DESCRIPTION="Probe builtin for HYPE CLI"
-BUILTIN_COMMANDS+=("probe")
+BUILTIN_DESCRIPTION="Releases builtin for HYPE CLI"
+BUILTIN_COMMANDS+=("releases")
 
 # Builtin initialization function (optional)
-builtin_probe_init() {
+builtin_releases_init() {
     debug "Builtin $BUILTIN_NAME initialized"
 }
 
@@ -32,25 +32,25 @@ check_helm_release_exists() {
     fi
 }
 
-# Probe release command - check if all releases in releaseProbe list exist
-cmd_probe_release() {
+# Check command - check if all releases in releases list exist
+cmd_releases_check() {
     local hype_name="$1"
     
-    debug "Probing releases for hype: $hype_name"
+    debug "Checking releases for hype: $hype_name"
     
     # Parse hypefile to get access to hype section
     parse_hypefile "$hype_name"
     
-    # Get release probe list
+    # Get releases list
     local release_list
-    if ! release_list=$(get_release_probe_list); then
-        error "Failed to get release probe list from hypefile"
+    if ! release_list=$(get_releases_list); then
+        error "Failed to get releases list from hypefile"
         exit 1
     fi
     
     # Check if release list is empty
     if [[ -z "$release_list" ]]; then
-        info "No releases to probe - releaseProbe list is empty"
+        info "No releases to check - releases list is empty"
         exit 0
     fi
     
@@ -76,53 +76,53 @@ cmd_probe_release() {
 }
 
 # Main command function
-cmd_probe() {
+cmd_releases() {
     local hype_name="$1"
     local subcommand="${2:-}"
     shift 2
     
     case "$subcommand" in
-        "release")
-            cmd_probe_release "$hype_name" "$@"
+        "check")
+            cmd_releases_check "$hype_name" "$@"
             ;;
         "help"|"-h"|"--help"|"")
-            help_probe
+            help_releases
             ;;
         *)
-            error "Unknown probe subcommand: $subcommand"
-            help_probe
+            error "Unknown releases subcommand: $subcommand"
+            help_releases
             exit 1
             ;;
     esac
 }
 
 # Help function for this builtin
-help_probe() {
+help_releases() {
     cat << EOF
-Usage: hype <hype-name> probe <subcommand> [options...]
+Usage: hype <hype-name> releases <subcommand> [options...]
 
-Probe builtin for HYPE CLI - check status of various components
+Releases builtin for HYPE CLI - manage and check status of releases
 
 Subcommands:
-  release                 Check if all releases in releaseProbe list exist
+  check                   Check if all releases in releases list exist
   help, -h, --help       Show this help message
 
 Examples:
-  hype my-hype probe release      Check if all releases are present
-  hype my-hype probe help         Show this help
+  hype my-hype releases check     Check if all releases are present
+  hype my-hype releases help      Show this help
 
-The 'release' subcommand checks if all helm releases listed in the 
-hypefile.yaml hype.releaseProbe section exist, regardless of their status.
+The 'check' subcommand checks if all helm releases listed in the 
+hypefile.yaml releases section exist, regardless of their status.
 Returns exit code 0 if all releases exist, 1 if any are missing.
 EOF
 }
 
 # Brief help for main help display
-help_probe_brief() {
-    echo "Check status of various HYPE components"
+help_releases_brief() {
+    echo "Manage and check status of HYPE releases"
 }
 
 # Builtin cleanup function (optional)
-builtin_probe_cleanup() {
+builtin_releases_cleanup() {
     debug "Builtin $BUILTIN_NAME cleaned up"
 }

--- a/src/core/hypefile.sh
+++ b/src/core/hypefile.sh
@@ -99,12 +99,12 @@ get_default_resources() {
     yq eval '.defaultResources[]' "$HYPE_SECTION_FILE" 2>/dev/null || true
 }
 
-# Get release probe list from hype section
+# Get releases list from hype section
 # Note: Template variables are already expanded by parse_hypefile()
-get_release_probe_list() {
+get_releases_list() {
     if [[ ! -f "$HYPE_SECTION_FILE" ]]; then
         return
     fi
     
-    yq eval '.releaseProbe[]' "$HYPE_SECTION_FILE" 2>/dev/null || true
+    yq eval '.releases[]' "$HYPE_SECTION_FILE" 2>/dev/null || true
 }

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -132,7 +132,7 @@ test_builtin_structure() {
     echo "Testing builtin structure..."
     
     local builtins_found=0
-    local expected_builtins=("init" "template" "parse" "trait" "upgrade" "task" "helmfile" "probe")
+    local expected_builtins=("init" "template" "parse" "trait" "upgrade" "task" "helmfile" "releases")
     
     for builtin in "${expected_builtins[@]}"; do
         if [[ -f "$PROJECT_ROOT/src/builtins/${builtin}.sh" ]]; then

--- a/tests/unit/test-releases.sh
+++ b/tests/unit/test-releases.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Unit tests for probe builtin
+# Unit tests for releases builtin
 
 # Create test environment
 setup_test_env() {
@@ -18,12 +18,12 @@ cleanup_test_env() {
     fi
 }
 
-# Create test hypefile with releaseProbe section
+# Create test hypefile with releases section
 create_test_hypefile() {
     local hype_name="$1"
     cat > "$HYPEFILE" << EOF
 hype:
-  releaseProbe:
+  releases:
     - hype-common
     - ${hype_name}-core-system
     - static-release
@@ -93,11 +93,11 @@ source_modules() {
     source "src/core/common.sh"
     source "src/core/config.sh"
     source "src/core/hypefile.sh"
-    source "src/builtins/probe.sh"
+    source "src/builtins/releases.sh"
 }
 
-# Test get_release_probe_list function
-test_get_release_probe_list() {
+# Test get_releases_list function
+test_get_releases_list() {
     setup_test_env
     create_test_hypefile "test-app"
     source_modules
@@ -107,17 +107,17 @@ test_get_release_probe_list() {
     
     # Get release list
     local releases
-    releases=$(get_release_probe_list)
+    releases=$(get_releases_list)
     
     # Check if expected releases are returned
     if echo "$releases" | grep -q "hype-common" && \
        echo "$releases" | grep -q "test-app-core-system" && \
        echo "$releases" | grep -q "static-release"; then
-        echo "✓ get_release_probe_list returns expected releases"
+        echo "✓ get_releases_list returns expected releases"
         cleanup_test_env
         return 0
     else
-        echo "✗ get_release_probe_list failed: $releases"
+        echo "✗ get_releases_list failed: $releases"
         cleanup_test_env
         return 1
     fi
@@ -134,7 +134,7 @@ test_template_expansion() {
     
     # Get release list
     local releases
-    releases=$(get_release_probe_list)
+    releases=$(get_releases_list)
     
     # Check if template variable was expanded
     if echo "$releases" | grep -q "my-service-core-system"; then
@@ -148,73 +148,73 @@ test_template_expansion() {
     fi
 }
 
-# Test probe release with all releases existing
-test_probe_release_success() {
+# Test releases check with all releases existing
+test_releases_check_success() {
     setup_test_env
     create_test_hypefile "test-app"
     source_modules
     mock_helm_success
     
-    # Run probe release command
-    if cmd_probe_release "test-app" >/dev/null 2>&1; then
-        echo "✓ probe release succeeds when all releases exist"
+    # Run releases check command
+    if cmd_releases_check "test-app" >/dev/null 2>&1; then
+        echo "✓ releases check succeeds when all releases exist"
         cleanup_test_env
         return 0
     else
-        echo "✗ probe release failed when all releases should exist"
+        echo "✗ releases check failed when all releases should exist"
         cleanup_test_env
         return 1
     fi
 }
 
-# Test probe release with missing releases
-test_probe_release_failure() {
+# Test releases check with missing releases
+test_releases_check_failure() {
     setup_test_env
     create_test_hypefile "test-app"
     source_modules
     mock_helm_partial_failure
     
-    # Run probe release command
-    if ! cmd_probe_release "test-app" >/dev/null 2>&1; then
-        echo "✓ probe release fails when some releases are missing"
+    # Run releases check command
+    if ! cmd_releases_check "test-app" >/dev/null 2>&1; then
+        echo "✓ releases check fails when some releases are missing"
         cleanup_test_env
         return 0
     else
-        echo "✗ probe release succeeded when it should have failed"
+        echo "✗ releases check succeeded when it should have failed"
         cleanup_test_env
         return 1
     fi
 }
 
-# Test empty releaseProbe list
-test_empty_release_probe() {
+# Test empty releases list
+test_empty_releases() {
     setup_test_env
     cat > "$HYPEFILE" << EOF
 hype:
-  releaseProbe: []
+  releases: []
 EOF
     source_modules
     
-    # Run probe release command
-    if cmd_probe_release "test-app" >/dev/null 2>&1; then
-        echo "✓ probe release succeeds with empty releaseProbe list"
+    # Run releases check command
+    if cmd_releases_check "test-app" >/dev/null 2>&1; then
+        echo "✓ releases check succeeds with empty releases list"
         cleanup_test_env
         return 0
     else
-        echo "✗ probe release failed with empty releaseProbe list"
+        echo "✗ releases check failed with empty releases list"
         cleanup_test_env
         return 1
     fi
 }
 
 # Run tests
-echo "Probe Builtin Unit Tests"
-echo "========================"
+echo "Releases Builtin Unit Tests"
+echo "==========================="
 
-test_get_release_probe_list
+test_get_releases_list
 test_template_expansion
-test_probe_release_success
-test_probe_release_failure
-test_empty_release_probe
+test_releases_check_success
+test_releases_check_failure
+test_empty_releases
 
-echo "Probe tests completed"
+echo "Releases tests completed"


### PR DESCRIPTION
## Summary
- `hype <name> probe release` コマンドを `hype <name> releases check` に変更
- `releaseProbe` 設定キーを `releases` キーに変名（`defaultResources` と同列）
- 関連するファイル名、関数名、テスト、ドキュメントを全て更新

## Test plan
- [x] `task build` でビルド成功
- [x] `task test` で全テスト通過（45/45）
- [x] `./build/hype test releases --help` でヘルプ表示確認
- [x] ShellCheck による静的解析通過

🤖 Generated with [Claude Code](https://claude.ai/code)