### PR TITLE
Add exit codes to repo command for scriptable repository binding checks

### DIFF
--- a/src/builtins/repo.sh
+++ b/src/builtins/repo.sh
@@ -369,36 +369,41 @@ cmd_repo_info() {
         [[ -n "$bound_at" ]] && echo "  Bound at: $bound_at"
         [[ -n "$last_updated" ]] && echo "  Last updated: $last_updated"
         
+        # Check cache status
+        local cache_dir
+        cache_dir=$(get_repo_cache_dir "$hype_name")
+        
+        echo ""
+        if is_valid_cache "$cache_dir"; then
+            info "Cache status: Available"
+            echo "  Cache directory: $cache_dir"
+            
+            # Show repository status
+            local status
+            if status=$(get_repo_status "$cache_dir"); then
+                echo ""
+                echo "Repository status:"
+                while IFS= read -r line; do
+                    echo "  $line"
+                done <<< "$status"
+            fi
+        else
+            warn "Cache status: Missing or invalid"
+            info "Run 'hype $hype_name repo update' to update the cache"
+        fi
+        
+        # Exit with success code when repo binding exists
+        exit 0
+        
     else
         info "No repository binding found for '$hype_name'"
         info "This hype name is using local configuration only."
         info ""
         info "To bind a repository, use:"
         info "  hype $hype_name repo bind <repository-url>"
-        return 0
-    fi
-    
-    # Check cache status
-    local cache_dir
-    cache_dir=$(get_repo_cache_dir "$hype_name")
-    
-    echo ""
-    if is_valid_cache "$cache_dir"; then
-        info "Cache status: Available"
-        echo "  Cache directory: $cache_dir"
         
-        # Show repository status
-        local status
-        if status=$(get_repo_status "$cache_dir"); then
-            echo ""
-            echo "Repository status:"
-            while IFS= read -r line; do
-                echo "  $line"
-            done <<< "$status"
-        fi
-    else
-        warn "Cache status: Missing or invalid"
-        info "Run 'hype $hype_name repo update' to update the cache"
+        # Exit with failure code when repo binding does not exist
+        exit 1
     fi
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- repo command now exits with 0 when repository binding exists
- repo command now exits with 1 when repository binding does not exist
- Enables scriptable checks for repository binding status using exit codes
- Maintains existing functionality while adding exit code semantics

## Changes
- Modified `cmd_repo_info()` function in `src/builtins/repo.sh`
- Added explicit `exit 0` when repository binding exists
- Added explicit `exit 1` when repository binding does not exist
- Moved cache status check logic inside the binding exists branch

## Use Cases
This enables scriptable repository binding checks:
```bash
if hype myapp repo; then
    echo "Repository is bound"
else
    echo "Repository is not bound"
fi
```

## Testing
- [x] Built successfully with `task build`
- [x] Linting passes with `task lint`
- [x] Maintains backward compatibility (output remains the same)

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)