### PR TITLE
Restructure resources subcommand behavior

### DIFF
--- a/src/builtins/resources.sh
+++ b/src/builtins/resources.sh
@@ -46,12 +46,11 @@ check_resource_status() {
     esac
 }
 
-# Check command - check status of default resources
+# Check command - display current resources and check if configuration exists
 cmd_resources_check() {
     local hype_name="$1"
-    local has_missing_resources=false
     
-    info "Resource status for: $hype_name"
+    info "Resources for: $hype_name"
     echo
     
     parse_hypefile "$hype_name"
@@ -66,11 +65,11 @@ cmd_resources_check() {
     resource_count=$(yq eval '.defaultResources | length' "$HYPE_SECTION_FILE" 2>/dev/null || echo "0")
     
     if [[ "$resource_count" -eq 0 ]]; then
-        info "No default resources found"
+        info "No default resources configured"
         exit 1
     fi
     
-    # Check status of each default resource
+    # Display each default resource
     for (( i=0; i<resource_count; i++ )); do
         local name type
         
@@ -79,22 +78,20 @@ cmd_resources_check() {
         
         if [[ "$type" != "null" ]]; then
             if [[ "$type" == "DefaultStateValues" ]]; then
-                # DefaultStateValues doesn't have a name, use type for status
-                check_resource_status "" "$type"
+                echo "  - Type: $type (local processing)"
             elif [[ "$name" != "null" ]]; then
-                if ! check_resource_status "$name" "$type"; then
-                    has_missing_resources=true
-                fi
+                echo "  - Name: $name, Type: $type"
+            else
+                echo "  - Type: $type"
             fi
         fi
     done
     
-    # Exit with appropriate status
-    if [[ "$has_missing_resources" == true ]]; then
-        exit 1
-    else
-        exit 0
-    fi
+    echo
+    info "Found $resource_count configured resource(s)"
+    
+    # Exit with status 0 since resources are configured
+    exit 0
 }
 
 # Main command function for resources
@@ -132,18 +129,17 @@ Usage: hype <hype-name> resources <subcommand> [options...]
 Resources builtin for HYPE CLI - manage and check status of resources
 
 Subcommands:
-  check                   Check status of default resources (exit 0 if all exist, exit 1 if any missing)
+  check                   Display current resources and check if configuration exists (exit 0 if exists, exit 1 if not)
   help, -h, --help       Show this help message
 
 Examples:
   hype my-nginx resources         Show this help
-  hype my-nginx resources check   Check resource status for my-nginx
+  hype my-nginx resources check   Display current resources for my-nginx
   hype my-nginx resources help    Show this help
 
-The 'check' subcommand lists all default resources defined in the 
-hypefile.yaml and shows their current status in the Kubernetes cluster.
-It exits with status 0 if all resources exist, or status 1 if any are missing
-or if no resources are configured.
+The 'check' subcommand displays all default resources defined in the 
+hypefile.yaml. It exits with status 0 if resources are configured, 
+or status 1 if no resources are configured.
 EOF
 }
 


### PR DESCRIPTION
## Summary

- Restructures resources subcommand to focus on displaying current resources
- Changes `resources check` from cluster state validation to configuration display
- Maintains backward compatibility for help display

## Implementation Details

Updates the `resources` subcommand behavior:

### Current Behavior
- `hype <name> resources` → shows help (unchanged)
- `hype <name> resources check` → now displays configured resources and exits with 0 if configured, 1 if not

### Changes Made
- Modified `cmd_resources_check()` to display resources instead of checking cluster state
- Updated help documentation to reflect new behavior
- Simplified exit logic: 0 for configured resources, 1 for no configuration

## Usage Examples

```bash
# Show help (unchanged)
hype my-nginx resources

# Display current configured resources  
hype my-nginx resources check
```

## Sample Output

```
Resources for: my-nginx

  - Name: my-nginx-nginx-state-values, Type: StateValuesConfigmap
  - Name: my-nginx-nginx-secrets, Type: Secrets
  - Type: DefaultStateValues (local processing)

Found 3 configured resource(s)
```

## Test Results

- ✅ Build successful
- ✅ Help command works correctly  
- ✅ Resources display correctly when configured
- ✅ Exits with code 1 when no configuration found
- ✅ Exits with code 0 when resources are configured
- ✅ ShellCheck passes
- ✅ 46/47 tests pass (1 existing test failure unrelated to changes)

🤖 Generated with [Claude Code](https://claude.ai/code)