### PR TITLE
Add addons subcommand functionality

### DIFF
--- a/prompts/depends-example/hypefile.yaml
+++ b/prompts/depends-example/hypefile.yaml
@@ -2,3 +2,7 @@
 dependsOn:
   - hype: my-depend
     prepare: foontype/hype --path prompts/nginx-example
+
+addons:
+  - hype: my-addon
+    prepare: foontype/hype --path prompts/nginx-example

--- a/src/builtins/addons.sh
+++ b/src/builtins/addons.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+# HYPE CLI Addons Builtin
+# Manage addons for hype instances
+
+BUILTIN_NAME="addons"
+# shellcheck disable=SC2034
+BUILTIN_VERSION="1.0.0"
+# shellcheck disable=SC2034
+BUILTIN_DESCRIPTION="Manage addons for hype instances"
+BUILTIN_COMMANDS+=("addons")
+
+builtin_addons_init() {
+    debug "Builtin $BUILTIN_NAME initialized"
+}
+
+cmd_addons() {
+    local hype_name="$1"
+    shift
+    local subcommand="${1:-}"
+    
+    case "$subcommand" in
+        "up")
+            addons_up "$hype_name"
+            ;;
+        "down")
+            addons_down "$hype_name"
+            ;;
+        "list")
+            addons_list "$hype_name"
+            ;;
+        "help"|"-h"|"--help")
+            help_addons
+            ;;
+        "")
+            error "Missing subcommand. Use 'up', 'down', 'list', or 'help'"
+            help_addons
+            return 1
+            ;;
+        *)
+            error "Unknown addons subcommand: $subcommand"
+            help_addons
+            return 1
+            ;;
+    esac
+}
+
+addons_up() {
+    local hype_name="$1"
+    
+    info "Starting addons for $hype_name"
+    
+    parse_hypefile "$hype_name"
+    
+    local addons_list
+    if ! addons_list=$(get_addons_list); then
+        debug "No addons found for $hype_name"
+        return 0
+    fi
+    
+    if [[ -z "$addons_list" ]]; then
+        debug "No addons configured for $hype_name"
+        return 0
+    fi
+    
+    local count=0
+    local current_entry=""
+    
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^hype:.*$ ]]; then
+            # Process previous entry if exists
+            if [[ -n "$current_entry" ]]; then
+                count=$((count + 1))
+                local addon_hype
+                local addon_prepare
+                
+                addon_hype=$(echo "$current_entry" | yq eval '.hype' -)
+                addon_prepare=$(echo "$current_entry" | yq eval '.prepare' -)
+                
+                if [[ -z "$addon_hype" || "$addon_hype" == "null" ]]; then
+                    error "Addon $count: missing 'hype' field"
+                    return 1
+                fi
+                
+                if [[ -z "$addon_prepare" || "$addon_prepare" == "null" ]]; then
+                    error "Addon $count: missing 'prepare' field"
+                    return 1
+                fi
+                
+                info "Processing addon $count: $addon_hype"
+                debug "Running: cmd_prepare $addon_hype $addon_prepare"
+                
+                if ! eval "cmd_prepare $addon_hype $addon_prepare"; then
+                    error "Failed to prepare addon: $addon_hype"
+                    return 1
+                fi
+                
+                info "Addon $count completed: $addon_hype"
+            fi
+            
+            # Start new entry
+            current_entry="$line"
+        else
+            # Continue building current entry
+            current_entry="$current_entry"$'\n'"$line"
+        fi
+    done <<< "$addons_list"
+    
+    # Process last entry
+    if [[ -n "$current_entry" ]]; then
+        count=$((count + 1))
+        local addon_hype
+        local addon_prepare
+        
+        addon_hype=$(echo "$current_entry" | yq eval '.hype' -)
+        addon_prepare=$(echo "$current_entry" | yq eval '.prepare' -)
+        
+        if [[ -z "$addon_hype" || "$addon_hype" == "null" ]]; then
+            error "Addon $count: missing 'hype' field"
+            return 1
+        fi
+        
+        if [[ -z "$addon_prepare" || "$addon_prepare" == "null" ]]; then
+            error "Addon $count: missing 'prepare' field"
+            return 1
+        fi
+        
+        info "Processing addon $count: $addon_hype"
+        debug "Running: cmd_prepare $addon_hype $addon_prepare"
+        
+        if ! eval "cmd_prepare $addon_hype $addon_prepare"; then
+            error "Failed to prepare addon: $addon_hype"
+            return 1
+        fi
+        
+        info "Addon $count completed: $addon_hype"
+    fi
+    
+    if [[ $count -eq 0 ]]; then
+        debug "No valid addons found for $hype_name"
+    else
+        info "All $count addons started for $hype_name"
+    fi
+}
+
+addons_down() {
+    local hype_name="$1"
+    
+    info "Stopping addons for $hype_name"
+    
+    parse_hypefile "$hype_name"
+    
+    local addons_list
+    if ! addons_list=$(get_addons_list); then
+        debug "No addons found for $hype_name"
+        return 0
+    fi
+    
+    if [[ -z "$addons_list" ]]; then
+        debug "No addons configured for $hype_name"
+        return 0
+    fi
+    
+    local addon_array=()
+    local current_entry=""
+    
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^hype:.*$ ]]; then
+            # Process previous entry if exists
+            if [[ -n "$current_entry" ]]; then
+                local addon_hype
+                addon_hype=$(echo "$current_entry" | yq eval '.hype' -)
+                
+                if [[ -n "$addon_hype" && "$addon_hype" != "null" ]]; then
+                    addon_array+=("$addon_hype")
+                fi
+            fi
+            
+            # Start new entry
+            current_entry="$line"
+        else
+            # Continue building current entry
+            current_entry="$current_entry"$'\n'"$line"
+        fi
+    done <<< "$addons_list"
+    
+    # Process last entry
+    if [[ -n "$current_entry" ]]; then
+        local addon_hype
+        addon_hype=$(echo "$current_entry" | yq eval '.hype' -)
+        
+        if [[ -n "$addon_hype" && "$addon_hype" != "null" ]]; then
+            addon_array+=("$addon_hype")
+        fi
+    fi
+    
+    local count=${#addon_array[@]}
+    if [[ $count -eq 0 ]]; then
+        debug "No valid addons found for $hype_name"
+        return 0
+    fi
+    
+    for ((i = count - 1; i >= 0; i--)); do
+        local addon_hype="${addon_array[i]}"
+        local addon_num=$((count - i))
+        
+        info "Stopping addon $addon_num: $addon_hype"
+        debug "Running: hype $addon_hype helmfile destroy"
+        
+        if ! hype "$addon_hype" helmfile destroy; then
+            error "Failed to destroy addon: $addon_hype"
+            return 1
+        fi
+        
+        info "Addon $addon_num stopped: $addon_hype"
+    done
+    
+    info "All $count addons stopped for $hype_name"
+}
+
+addons_list() {
+    local hype_name="$1"
+    
+    parse_hypefile "$hype_name"
+    
+    local addons_list
+    if ! addons_list=$(get_addons_list); then
+        info "No addons found for $hype_name"
+        return 0
+    fi
+    
+    if [[ -z "$addons_list" ]]; then
+        info "No addons configured for $hype_name"
+        return 0
+    fi
+    
+    info "Addons for $hype_name:"
+    local count=0
+    local current_entry=""
+    
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^hype:.*$ ]]; then
+            # Process previous entry if exists
+            if [[ -n "$current_entry" ]]; then
+                count=$((count + 1))
+                local addon_hype
+                local addon_prepare
+                
+                addon_hype=$(echo "$current_entry" | yq eval '.hype' -)
+                addon_prepare=$(echo "$current_entry" | yq eval '.prepare' -)
+                
+                echo "  $count. $addon_hype"
+                echo "     prepare: $addon_prepare"
+            fi
+            
+            # Start new entry
+            current_entry="$line"
+        else
+            # Continue building current entry
+            current_entry="$current_entry"$'\n'"$line"
+        fi
+    done <<< "$addons_list"
+    
+    # Process last entry
+    if [[ -n "$current_entry" ]]; then
+        count=$((count + 1))
+        local addon_hype
+        local addon_prepare
+        
+        addon_hype=$(echo "$current_entry" | yq eval '.hype' -)
+        addon_prepare=$(echo "$current_entry" | yq eval '.prepare' -)
+        
+        echo "  $count. $addon_hype"
+        echo "     prepare: $addon_prepare"
+    fi
+    
+    if [[ $count -eq 0 ]]; then
+        info "No valid addons found"
+    fi
+}
+
+help_addons() {
+    cat << EOF
+Usage: hype <hype-name> addons <command>
+
+Manage addons for hype instances
+
+Commands:
+  up          Start all addons in order
+  down        Stop all addons in reverse order
+  list        List configured addons
+  help        Show this help message
+
+The addons are configured in the hype section of hypefile.yaml:
+
+  addons:
+    - hype: addon-name
+      prepare: "repo/path --option value"
+    - hype: another-addon
+      prepare: "local/repo --path example"
+
+Examples:
+  hype myapp addons up       Start all addons for myapp
+  hype myapp addons down     Stop all addons for myapp
+  hype myapp addons list     List addons for myapp
+EOF
+}
+
+help_addons_brief() {
+    echo "Manage addons for hype instances"
+}
+
+builtin_addons_cleanup() {
+    debug "Builtin $BUILTIN_NAME cleaned up"
+}

--- a/src/core/hypefile.sh
+++ b/src/core/hypefile.sh
@@ -117,3 +117,12 @@ get_depends_list() {
     
     yq eval '.dependsOn[] | @yaml' "$HYPE_SECTION_FILE" 2>/dev/null | sed '/^---$/d' || true
 }
+
+# Get addons list from hype section
+get_addons_list() {
+    if [[ ! -f "$HYPE_SECTION_FILE" ]]; then
+        return
+    fi
+    
+    yq eval '.addons[] | @yaml' "$HYPE_SECTION_FILE" 2>/dev/null | sed '/^---$/d' || true
+}

--- a/tests/unit/test-addons.sh
+++ b/tests/unit/test-addons.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# Unit tests for addons functionality
+# Tests parsing of addons section from hypefile.yaml
+
+# Source test framework
+source "$(dirname "$0")/test-framework.sh"
+
+# Create test hypefile with addons section
+create_test_hypefile_with_addons() {
+    cat > "$HYPEFILE" << 'EOF'
+---
+hype:
+  name: test-app
+  trait: test
+
+defaultResources:
+  - name: "test-resource"
+    type: StateValuesConfigmap
+
+addons:
+  - hype: test-addon1
+    prepare: "repo1/test --path example1"
+  - hype: test-addon2
+    prepare: "repo2/test --path example2"
+
+expectedReleases:
+  - nginx
+---
+releases:
+  - name: nginx
+    chart: bitnami/nginx
+EOF
+}
+
+# Create test hypefile without addons
+create_test_hypefile_without_addons() {
+    cat > "$HYPEFILE" << 'EOF'
+---
+hype:
+  name: test-app
+  trait: test
+
+defaultResources:
+  - name: "test-resource"
+    type: StateValuesConfigmap
+
+expectedReleases:
+  - nginx
+---
+releases:
+  - name: nginx
+    chart: bitnami/nginx
+EOF
+}
+
+# Test parsing addons section
+test_addons_parsing() {
+    setup_test "test_addons_parsing"
+    
+    create_test_hypefile_with_addons
+    parse_hypefile "test-app"
+    
+    # Get addons list
+    local addons_list
+    addons_list=$(get_addons_list)
+    
+    if [[ -n "$addons_list" ]]; then
+        # Count number of addons
+        local count=0
+        local current_entry=""
+        
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^hype:.*$ ]]; then
+                if [[ -n "$current_entry" ]]; then
+                    count=$((count + 1))
+                fi
+                current_entry="$line"
+            else
+                current_entry="$current_entry"$'\n'"$line"
+            fi
+        done <<< "$addons_list"
+        
+        # Process last entry
+        if [[ -n "$current_entry" ]]; then
+            count=$((count + 1))
+        fi
+        
+        if [[ $count -eq 2 ]]; then
+            echo "✓ addons section parsed correctly (found $count addons)"
+            return 0
+        else
+            echo "✗ addons section parsing failed (found $count addons, expected 2)"
+            return 1
+        fi
+    else
+        echo "✗ addons list is empty"
+        return 1
+    fi
+}
+
+# Test parsing hypefile without addons
+test_no_addons_parsing() {
+    setup_test "test_no_addons_parsing"
+    
+    create_test_hypefile_without_addons
+    parse_hypefile "test-app"
+    
+    # Get addons list
+    local addons_list
+    addons_list=$(get_addons_list)
+    
+    if [[ -z "$addons_list" ]]; then
+        echo "✓ No addons section correctly handled"
+        return 0
+    else
+        echo "✗ Should return empty for no addons section"
+        return 1
+    fi
+}
+
+# Test addons list command
+test_addons_list_command() {
+    setup_test "test_addons_list_command"
+    
+    create_test_hypefile_with_addons
+    
+    # Run addons list command
+    local output
+    if output=$(addons_list "test-app" 2>&1); then
+        if echo "$output" | grep -q "test-addon1" && echo "$output" | grep -q "test-addon2"; then
+            echo "✓ addons list command shows configured addons"
+            return 0
+        else
+            echo "✗ addons list command missing expected addons"
+            echo "Output: $output"
+            return 1
+        fi
+    else
+        echo "✗ addons list command failed"
+        return 1
+    fi
+}
+
+# Test addons parsing with malformed YAML
+test_addons_parsing_malformed() {
+    setup_test "test_addons_parsing_malformed"
+    
+    # Create malformed hypefile
+    cat > "$HYPEFILE" << 'EOF'
+---
+hype:
+  name: test-app
+  trait: test
+
+addons:
+  - hype: test-addon1
+    # Missing prepare field
+  - prepare: "repo2/test --path example2"
+    # Missing hype field
+
+expectedReleases:
+  - nginx
+---
+releases:
+  - name: nginx
+    chart: bitnami/nginx
+EOF
+    
+    parse_hypefile "test-app"
+    
+    # Get addons list should still work, but entries may be incomplete
+    local addons_list
+    addons_list=$(get_addons_list)
+    
+    if [[ -n "$addons_list" ]]; then
+        echo "✓ Malformed addons handled gracefully"
+        return 0
+    else
+        echo "✓ Empty result for malformed addons is acceptable"
+        return 0
+    fi
+}
+
+# Run tests
+run_tests() {
+    echo "Running addons functionality tests..."
+    
+    local total=0
+    local passed=0
+    
+    tests=(
+        test_addons_parsing
+        test_no_addons_parsing
+        test_addons_list_command
+        test_addons_parsing_malformed
+    )
+    
+    for test_func in "${tests[@]}"; do
+        total=$((total + 1))
+        echo "Running $test_func..."
+        if $test_func; then
+            passed=$((passed + 1))
+        fi
+        echo ""
+    done
+    
+    echo "Addons tests completed: $passed/$total passed"
+    
+    if [[ $passed -eq $total ]]; then
+        echo "✓ All addons tests passed"
+        return 0
+    else
+        echo "✗ Some addons tests failed"
+        return 1
+    fi
+}
+
+# Only run tests if called directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_tests
+fi


### PR DESCRIPTION
## Summary
- Add `addons` subcommand to manage addons for hype instances
- Support same data structure as `dependsOn` for consistency
- Implement up/down/list/help commands for addons management

## Changes Made
- **src/core/hypefile.sh**: Add `get_addons_list()` function to parse addons from hypefile
- **src/builtins/addons.sh**: Create complete addons module with all subcommands
- **tests/unit/test-addons.sh**: Add comprehensive unit tests for addons functionality

## New Commands
- `hype <hype-name> addons up` - Start all addons in order using `hype prepare`
- `hype <hype-name> addons down` - Stop all addons in reverse order using `helmfile destroy`  
- `hype <hype-name> addons list` - List configured addons with their prepare commands
- `hype <hype-name> addons help` - Show detailed help for addons commands

## Data Structure
Addons use the same YAML structure as `dependsOn`:
```yaml
addons:
  - hype: my-addon
    prepare: "foontype/hype --path prompts/nginx-example"
  - hype: another-addon
    prepare: "local/repo --option value"
```

## Test plan
- [x] Build passes with new addons module included
- [x] All existing tests continue to pass
- [x] New addons unit tests verify parsing and list functionality
- [x] Manual testing confirms help, list, and command routing work correctly
- [x] ShellCheck validates code quality for new addons.sh module

🤖 Generated with [Claude Code](https://claude.ai/code)