### PR TITLE
Rename dependsOn key to depends in hypefile configuration

### DIFF
--- a/prompts/depends-example/hypefile.yaml
+++ b/prompts/depends-example/hypefile.yaml
@@ -1,5 +1,5 @@
 
-dependsOn:
+depends:
   - hype: my-depend
     prepare: foontype/hype --path prompts/nginx-example
 

--- a/src/builtins/aliases.sh
+++ b/src/builtins/aliases.sh
@@ -21,7 +21,7 @@ Usage: hype <hype-name> up
 Start dependencies, build and deploy (dependencies + task build + helmfile apply)
 
 This command performs a complete deployment workflow:
-1. Start all dependencies (if configured in dependsOn)
+1. Start all dependencies (if configured in depends)
 2. Run the build task (if available)
 3. Apply the helmfile configuration to deploy your application
 
@@ -60,7 +60,7 @@ Restart deployment (down + up)
 
 This command performs a restart workflow:
 1. Destroy the deployment (helmfile destroy)
-2. Start all dependencies (if configured in dependsOn)
+2. Start all dependencies (if configured in depends)
 3. Run the build task (if available)
 4. Deploy the application (helmfile apply)
 

--- a/src/builtins/depends.sh
+++ b/src/builtins/depends.sh
@@ -293,7 +293,7 @@ Commands:
 
 The dependencies are configured in the hype section of hypefile.yaml:
 
-  dependsOn:
+  depends:
     - hype: dependency-name
       prepare: "repo/path --option value"
     - hype: another-dependency

--- a/src/core/hypefile.sh
+++ b/src/core/hypefile.sh
@@ -115,7 +115,7 @@ get_depends_list() {
         return
     fi
     
-    yq eval '.dependsOn[] | @yaml' "$HYPE_SECTION_FILE" 2>/dev/null | sed '/^---$/d' || true
+    yq eval '.depends[] | @yaml' "$HYPE_SECTION_FILE" 2>/dev/null | sed '/^---$/d' || true
 }
 
 # Get addons list from hype section

--- a/tests/unit/test-depends.sh
+++ b/tests/unit/test-depends.sh
@@ -8,7 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../src/core/config.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/../../src/core/hypefile.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/../../src/builtins/depends.sh"
 
-# Create test hypefile with dependsOn section
+# Create test hypefile with depends section
 create_test_hypefile() {
     local test_file="$1"
     cat > "$test_file" << 'EOF'
@@ -16,7 +16,7 @@ defaultResources:
   - name: "test-resource"
     type: StateValuesConfigmap
 
-dependsOn:
+depends:
   - hype: test-dep1
     prepare: "repo1/test --path example1"
   - hype: test-dep2
@@ -48,7 +48,7 @@ releases:
 EOF
 }
 
-# Test parsing dependsOn section
+# Test parsing depends section
 test_parse_depends_section() {
     local test_hypefile=$(mktemp)
     create_test_hypefile "$test_hypefile"
@@ -70,10 +70,10 @@ test_parse_depends_section() {
     rm -f "$test_hypefile"
     
     if [[ $count -eq 2 ]]; then
-        echo "✓ dependsOn section parsed correctly (found $count dependencies)"
+        echo "✓ depends section parsed correctly (found $count dependencies)"
         return 0
     else
-        echo "✗ dependsOn section parsing failed (found $count dependencies, expected 2)"
+        echo "✗ depends section parsing failed (found $count dependencies, expected 2)"
         return 1
     fi
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `dependsOn` キーを `depends` に変名してより簡潔にしました
- 既存の機能は変更なく、キー名のみの変更です
- 関連する全てのドキュメントとテストを更新しました

## Changes Made
- `src/core/hypefile.sh`: `get_depends_list()` 関数で `.dependsOn[]` を `.depends[]` に変更
- `src/builtins/depends.sh`: ヘルプメッセージの例を更新
- `src/builtins/aliases.sh`: コメント内の参照を更新
- `tests/unit/test-depends.sh`: テストケースを新しいキー名に更新
- `prompts/depends-example/hypefile.yaml`: サンプルファイルを更新

## Test plan
- [x] `task build` でビルドが成功することを確認
- [x] `task test` で全てのテスト（51個）がパスすることを確認
- [x] depends サブコマンドの動作が変更されていないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)