### PR TITLE
Fix Trait template variable processing in helmfile section

### DIFF
--- a/src/core/hypefile.sh
+++ b/src/core/hypefile.sh
@@ -43,14 +43,16 @@ parse_hypefile() {
     sed -i "s/{{ \.Hype\.Name }}/$hype_name/g" "$HYPE_SECTION_FILE"
     sed -i "s|{{ \.Hype\.CurrentDirectory }}|$(pwd)|g" "$HYPE_SECTION_FILE"
     
-    # Replace {{ .Hype.Trait }} with actual trait value (hype section only)
+    # Replace {{ .Hype.Trait }} with actual trait value (hype and helmfile sections)
     local trait_value
     if trait_value=$(get_hype_trait "$hype_name" 2>/dev/null); then
         debug "Found trait for template replacement: $trait_value"
         sed -i "s/{{ \.Hype\.Trait }}/$trait_value/g" "$HYPE_SECTION_FILE"
+        sed -i "s/{{ \.Hype\.Trait }}/$trait_value/g" "$HELMFILE_SECTION_FILE"
     else
         debug "No trait found, removing trait template variables"
         sed -i "s/{{ \.Hype\.Trait }}//g" "$HYPE_SECTION_FILE"
+        sed -i "s/{{ \.Hype\.Trait }}//g" "$HELMFILE_SECTION_FILE"
     fi
     
     # Note: TASKFILE_SECTION_FILE is not processed here - it keeps its original template variables


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Extend Trait template variable (`{{ .Hype.Trait }}`) processing to include helmfile section
- Fix template errors when using Trait variables in helmfile section
- Maintain backward compatibility for existing functionality

## Problem
Previously, `{{ .Hype.Trait }}` template variables were only processed in the hype section of hypefile.yaml. When these variables were used in the helmfile section, they would cause template parsing errors, especially when no trait was set for a hype instance.

## Solution
Extended the trait template variable processing in `parse_hypefile()` function to apply sed replacements to both:
- `HYPE_SECTION_FILE` (existing behavior)
- `HELMFILE_SECTION_FILE` (new addition)

This ensures consistent template variable handling across all sections that support it.

## Changes
- Modified `src/core/hypefile.sh` to apply trait template replacements to helmfile section
- Updated comments to reflect the expanded scope
- Handles both cases: trait exists (replacement) and trait doesn't exist (removal)

## Test plan
- [x] Build the CLI successfully
- [x] Test with hypefile containing `{{ .Hype.Trait }}` in helmfile section
- [x] Verify both scenarios: with trait set and without trait set
- [x] Confirm depends down command works without template errors

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)