### PR TITLE
Add init/deinit/up/down subcommands for depends and addons

### DIFF
--- a/src/builtins/depends.sh
+++ b/src/builtins/depends.sh
@@ -20,6 +20,12 @@ cmd_depends() {
     local subcommand="${1:-}"
     
     case "$subcommand" in
+        "init")
+            depends_init "$hype_name"
+            ;;
+        "deinit")
+            depends_deinit "$hype_name"
+            ;;
         "up")
             depends_up "$hype_name"
             ;;
@@ -36,7 +42,7 @@ cmd_depends() {
             help_depends
             ;;
         "")
-            error "Missing subcommand. Use 'up', 'down', 'list', 'check', or 'help'"
+            error "Missing subcommand. Use 'init', 'deinit', 'up', 'down', 'list', 'check', or 'help'"
             help_depends
             return 1
             ;;
@@ -46,6 +52,187 @@ cmd_depends() {
             return 1
             ;;
     esac
+}
+
+depends_init() {
+    local hype_name="$1"
+
+    info "Initializing dependencies for $hype_name"
+
+    parse_hypefile "$hype_name"
+
+    local depends_list
+    if ! depends_list=$(get_depends_list); then
+        debug "No dependencies found for $hype_name"
+        return 0
+    fi
+
+    if [[ -z "$depends_list" ]]; then
+        debug "No dependencies configured for $hype_name"
+        return 0
+    fi
+
+    local count=0
+    local current_entry=""
+    local line
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^hype:.*$ ]]; then
+            # Process previous entry if exists
+            if [[ -n "$current_entry" ]]; then
+                # Check if this entry should be processed based on traits
+                if should_process_entry_by_traits "$current_entry" "$hype_name"; then
+                    count=$((count + 1))
+                    local depend_hype
+
+                    depend_hype=$(echo "$current_entry" | yq eval '.hype' -)
+
+                    if [[ -z "$depend_hype" || "$depend_hype" == "null" ]]; then
+                        error "Dependency $count: missing 'hype' field"
+                        return 1
+                    fi
+
+                    info "Initializing dependency $count: $depend_hype"
+                    debug "Running: hype $depend_hype init"
+
+                    if ! hype "$depend_hype" init; then
+                        error "Failed to initialize dependency: $depend_hype"
+                        return 1
+                    fi
+
+                    info "Dependency $count initialized: $depend_hype"
+                else
+                    debug "Skipping dependency due to trait mismatch"
+                fi
+            fi
+
+            # Start new entry
+            current_entry="$line"
+        else
+            # Continue building current entry
+            current_entry="$current_entry"$'\n'"$line"
+        fi
+    done <<< "$depends_list"
+
+    # Process last entry
+    if [[ -n "$current_entry" ]]; then
+        # Check if this entry should be processed based on traits
+        if should_process_entry_by_traits "$current_entry" "$hype_name"; then
+            count=$((count + 1))
+            local depend_hype
+
+            depend_hype=$(echo "$current_entry" | yq eval '.hype' -)
+
+            if [[ -z "$depend_hype" || "$depend_hype" == "null" ]]; then
+                error "Dependency $count: missing 'hype' field"
+                return 1
+            fi
+
+            info "Initializing dependency $count: $depend_hype"
+            debug "Running: hype $depend_hype init"
+
+            if ! hype "$depend_hype" init; then
+                error "Failed to initialize dependency: $depend_hype"
+                return 1
+            fi
+
+            info "Dependency $count initialized: $depend_hype"
+        else
+            debug "Skipping last dependency due to trait mismatch"
+        fi
+    fi
+
+    if [[ $count -eq 0 ]]; then
+        debug "No valid dependencies found for $hype_name"
+    else
+        info "All $count dependencies initialized for $hype_name"
+    fi
+}
+
+depends_deinit() {
+    local hype_name="$1"
+
+    info "Deinitializing dependencies for $hype_name"
+
+    parse_hypefile "$hype_name"
+
+    local depends_list
+    if ! depends_list=$(get_depends_list); then
+        debug "No dependencies found for $hype_name"
+        return 0
+    fi
+
+    if [[ -z "$depends_list" ]]; then
+        debug "No dependencies configured for $hype_name"
+        return 0
+    fi
+
+    local depend_array=()
+    local current_entry=""
+    local line
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^hype:.*$ ]]; then
+            # Process previous entry if exists
+            if [[ -n "$current_entry" ]]; then
+                # Check if this entry should be processed based on traits
+                if should_process_entry_by_traits "$current_entry" "$hype_name"; then
+                    local depend_hype
+                    depend_hype=$(echo "$current_entry" | yq eval '.hype' -)
+
+                    if [[ -n "$depend_hype" && "$depend_hype" != "null" ]]; then
+                        depend_array+=("$depend_hype")
+                    fi
+                else
+                    debug "Skipping dependency in deinit due to trait mismatch"
+                fi
+            fi
+
+            # Start new entry
+            current_entry="$line"
+        else
+            # Continue building current entry
+            current_entry="$current_entry"$'\n'"$line"
+        fi
+    done <<< "$depends_list"
+
+    # Process last entry
+    if [[ -n "$current_entry" ]]; then
+        # Check if this entry should be processed based on traits
+        if should_process_entry_by_traits "$current_entry" "$hype_name"; then
+            local depend_hype
+            depend_hype=$(echo "$current_entry" | yq eval '.hype' -)
+
+            if [[ -n "$depend_hype" && "$depend_hype" != "null" ]]; then
+                depend_array+=("$depend_hype")
+            fi
+        else
+            debug "Skipping last dependency in deinit due to trait mismatch"
+        fi
+    fi
+
+    local count=${#depend_array[@]}
+    if [[ $count -eq 0 ]]; then
+        debug "No valid dependencies found for $hype_name"
+        return 0
+    fi
+
+    for ((i = count - 1; i >= 0; i--)); do
+        local depend_hype="${depend_array[i]}"
+        local dep_num=$((count - i))
+
+        info "Deinitializing dependency $dep_num: $depend_hype"
+        debug "Running: hype $depend_hype deinit"
+
+        if ! hype "$depend_hype" deinit; then
+            error "Failed to deinitialize dependency: $depend_hype"
+            return 1
+        fi
+
+        info "Dependency $dep_num deinitialized: $depend_hype"
+    done
+
+    info "All $count dependencies deinitialized for $hype_name"
 }
 
 depends_up() {
@@ -61,12 +248,11 @@ depends_up() {
         return 0
     fi
 
-
     if [[ -z "$depends_list" ]]; then
         debug "No dependencies configured for $hype_name"
         return 0
     fi
-    
+
     local count=0
     local current_entry=""
     local line
@@ -79,26 +265,19 @@ depends_up() {
                 if should_process_entry_by_traits "$current_entry" "$hype_name"; then
                     count=$((count + 1))
                     local depend_hype
-                    local depend_prepare
 
                     depend_hype=$(echo "$current_entry" | yq eval '.hype' -)
-                    depend_prepare=$(echo "$current_entry" | yq eval '.prepare' -)
 
                     if [[ -z "$depend_hype" || "$depend_hype" == "null" ]]; then
                         error "Dependency $count: missing 'hype' field"
                         return 1
                     fi
 
-                    if [[ -z "$depend_prepare" || "$depend_prepare" == "null" ]]; then
-                        error "Dependency $count: missing 'prepare' field"
-                        return 1
-                    fi
-
                     info "Processing dependency $count: $depend_hype"
-                    debug "Running: cmd_prepare $depend_hype $depend_prepare"
+                    debug "Running: hype $depend_hype up --nothing-if-expected --build --push"
 
-                    if ! eval "cmd_prepare $depend_hype $depend_prepare"; then
-                        error "Failed to prepare dependency: $depend_hype"
+                    if ! hype "$depend_hype" up --nothing-if-expected --build --push; then
+                        error "Failed to start dependency: $depend_hype"
                         return 1
                     fi
 
@@ -107,7 +286,7 @@ depends_up() {
                     debug "Skipping dependency due to trait mismatch"
                 fi
             fi
-            
+
             # Start new entry
             current_entry="$line"
         else
@@ -115,33 +294,26 @@ depends_up() {
             current_entry="$current_entry"$'\n'"$line"
         fi
     done <<< "$depends_list"
-    
+
     # Process last entry
     if [[ -n "$current_entry" ]]; then
         # Check if this entry should be processed based on traits
         if should_process_entry_by_traits "$current_entry" "$hype_name"; then
             count=$((count + 1))
             local depend_hype
-            local depend_prepare
 
             depend_hype=$(echo "$current_entry" | yq eval '.hype' -)
-            depend_prepare=$(echo "$current_entry" | yq eval '.prepare' -)
 
             if [[ -z "$depend_hype" || "$depend_hype" == "null" ]]; then
                 error "Dependency $count: missing 'hype' field"
                 return 1
             fi
 
-            if [[ -z "$depend_prepare" || "$depend_prepare" == "null" ]]; then
-                error "Dependency $count: missing 'prepare' field"
-                return 1
-            fi
-
             info "Processing dependency $count: $depend_hype"
-            debug "Running: cmd_prepare $depend_hype $depend_prepare"
+            debug "Running: hype $depend_hype up --nothing-if-expected --build --push"
 
-            if ! eval "cmd_prepare $depend_hype $depend_prepare"; then
-                error "Failed to prepare dependency: $depend_hype"
+            if ! hype "$depend_hype" up --nothing-if-expected --build --push; then
+                error "Failed to start dependency: $depend_hype"
                 return 1
             fi
 
@@ -150,7 +322,7 @@ depends_up() {
             debug "Skipping last dependency due to trait mismatch"
         fi
     fi
-    
+
     if [[ $count -eq 0 ]]; then
         debug "No valid dependencies found for $hype_name"
     else
@@ -160,22 +332,22 @@ depends_up() {
 
 depends_down() {
     local hype_name="$1"
-    
+
     info "Stopping dependencies for $hype_name"
-    
+
     parse_hypefile "$hype_name"
-    
+
     local depends_list
     if ! depends_list=$(get_depends_list); then
         debug "No dependencies found for $hype_name"
         return 0
     fi
-    
+
     if [[ -z "$depends_list" ]]; then
         debug "No dependencies configured for $hype_name"
         return 0
     fi
-    
+
     local depend_array=()
     local current_entry=""
     local line
@@ -196,7 +368,7 @@ depends_down() {
                     debug "Skipping dependency in down due to trait mismatch"
                 fi
             fi
-            
+
             # Start new entry
             current_entry="$line"
         else
@@ -204,7 +376,7 @@ depends_down() {
             current_entry="$current_entry"$'\n'"$line"
         fi
     done <<< "$depends_list"
-    
+
     # Process last entry
     if [[ -n "$current_entry" ]]; then
         # Check if this entry should be processed based on traits
@@ -219,28 +391,28 @@ depends_down() {
             debug "Skipping last dependency in down due to trait mismatch"
         fi
     fi
-    
+
     local count=${#depend_array[@]}
     if [[ $count -eq 0 ]]; then
         debug "No valid dependencies found for $hype_name"
         return 0
     fi
-    
+
     for ((i = count - 1; i >= 0; i--)); do
         local depend_hype="${depend_array[i]}"
         local dep_num=$((count - i))
-        
+
         info "Stopping dependency $dep_num: $depend_hype"
-        debug "Running: hype $depend_hype helmfile destroy"
-        
-        if ! hype "$depend_hype" helmfile destroy; then
-            error "Failed to destroy dependency: $depend_hype"
+        debug "Running: hype $depend_hype down"
+
+        if ! hype "$depend_hype" down; then
+            error "Failed to stop dependency: $depend_hype"
             return 1
         fi
-        
+
         info "Dependency $dep_num stopped: $depend_hype"
     done
-    
+
     info "All $count dependencies stopped for $hype_name"
 }
 
@@ -408,7 +580,9 @@ Usage: hype <hype-name> depends <command>
 Manage dependencies between hype instances
 
 Commands:
-  up          Start all dependencies in order
+  init        Initialize all dependencies
+  deinit      Deinitialize all dependencies in reverse order
+  up          Start all dependencies with --nothing-if-expected --build --push
   down        Stop all dependencies in reverse order
   list        List configured dependencies
   check       Check if all dependency releases exist
@@ -418,12 +592,12 @@ The dependencies are configured in the hype section of hypefile.yaml:
 
   depends:
     - hype: dependency-name
-      prepare: "repo/path --option value"
       matchTraits: [trait1, trait2]  # Optional: only process if current trait matches
     - hype: another-dependency
-      prepare: "local/repo --path example"
 
 Examples:
+  hype myapp depends init     Initialize all dependencies for myapp
+  hype myapp depends deinit   Deinitialize all dependencies for myapp
   hype myapp depends up       Start all dependencies for myapp
   hype myapp depends down     Stop all dependencies for myapp
   hype myapp depends list     List dependencies for myapp


### PR DESCRIPTION
## Summary

- **depends init**: `hype <depends hype name> init`を各依存関係に対して実行
- **depends deinit**: `hype <depends hype name> deinit`を逆順で実行  
- **depends up**: `hype <depends hype name> up --nothing-if-expected --build --push`を実行
- **depends down**: `hype <depends hype name> down`を逆順で実行
- **addons init**: `hype <addons hype name> init`を各アドオンに対して実行
- **addons deinit**: `hype <addons hype name> deinit`を逆順で実行
- **addons up**: `hype <addons hype name> up --nothing-if-expected --build --push`を実行  
- **addons down**: `hype <addons hype name> down`を逆順で実行
- 全てのコマンドで`matchTraits`フィールドによるtraitフィルタリングをサポート
- 新しいサブコマンドのヘルプテキストを更新

## Test plan

- [x] ビルドテスト: `task build`が成功
- [x] リンティング: `task lint`が成功  
- [x] ヘルプテスト: 新しいサブコマンドのヘルプが正しく表示される
- [x] リストテスト: `depends list`と`addons list`が動作
- [ ] 統合テスト: 実際のhypefileでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)