### PR TITLE
Remove obsolete smoke-test.md file

### DIFF
--- a/prompts/smoke-test.md
+++ b/prompts/smoke-test.md
@@ -1,1 +1,0 @@
-see prompts/v0.8.0/test.md for smoke testing.


### PR DESCRIPTION
## Summary
- Remove prompts/smoke-test.md file as it is no longer needed
- Smoke testing instructions have been moved to prompts/v0.8.0/test.md

## Test plan
- [ ] Verify the file has been removed
- [ ] Confirm that smoke testing documentation is available at prompts/v0.8.0/test.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)